### PR TITLE
Retry the schema query when pushing the schema version to account for eventual consistency

### DIFF
--- a/src/main/java/io/vlingo/xoom/schemata/query/SchemaQueries.java
+++ b/src/main/java/io/vlingo/xoom/schemata/query/SchemaQueries.java
@@ -16,4 +16,5 @@ public interface SchemaQueries {
   Completes<SchemasView> schemas(final String organizationId, final String unitId, final String contextId);
   Completes<SchemaView> schema(final String organizationId, final String unitId, final String contextId, final String schemaId);
   Completes<NamedSchemaView> schemaByNames(final String organization, final String unit, final String context, final String schema);
+  Completes<NamedSchemaView> schemaByNamesWithRetries(final String organization, final String unit, final String context, final String schema, int retryInterval, int retryTotal);
 }

--- a/src/main/java/io/vlingo/xoom/schemata/query/SchemaQueriesActor.java
+++ b/src/main/java/io/vlingo/xoom/schemata/query/SchemaQueriesActor.java
@@ -34,8 +34,15 @@ public class SchemaQueriesActor extends StateStoreQueryActor implements SchemaQu
 
     @Override
     public Completes<NamedSchemaView> schemaByNames(String organization, String unit, String context, String schema) {
-        Path path = Path.with(organization, unit, context, schema);
-        String reference = path.toReference();
-        return queryStateFor(reference, NamedSchemaView.class);
+        return queryStateFor(schemaReference(organization, unit, context, schema), NamedSchemaView.class);
+    }
+
+    @Override
+    public Completes<NamedSchemaView> schemaByNamesWithRetries(String organization, String unit, String context, String schema, int retryInterval, int retryTotal) {
+        return queryStateFor(schemaReference(organization, unit, context, schema), NamedSchemaView.class, retryInterval, retryTotal);
+    }
+
+    private String schemaReference(String organization, String unit, String context, String schema) {
+        return Path.with(organization, unit, context, schema).toReference();
     }
 }

--- a/src/main/java/io/vlingo/xoom/schemata/resource/SchemaVersionResource.java
+++ b/src/main/java/io/vlingo/xoom/schemata/resource/SchemaVersionResource.java
@@ -265,8 +265,8 @@ public class SchemaVersionResource extends DynamicResourceHandler {
               msg));
     }
 
-    SchemaVersionData updatedSchemaVersionData = schemaQueries.schemaByNames(fqr.organization,
-            fqr.unit, fqr.context, fqr.schema)
+    SchemaVersionData updatedSchemaVersionData = schemaQueries
+            .schemaByNamesWithRetries(fqr.organization, fqr.unit, fqr.context, fqr.schema, 500, 5)
             .andThenTo(namedSchemaView -> Completes.withSuccess(SchemaVersionData.from(
                     namedSchemaView.organizationId(),
                     namedSchemaView.unitId(),

--- a/src/test/java/io/vlingo/xoom/schemata/query/FailingStateStore.java
+++ b/src/test/java/io/vlingo/xoom/schemata/query/FailingStateStore.java
@@ -1,0 +1,69 @@
+package io.vlingo.xoom.schemata.query;
+
+import io.vlingo.xoom.common.Completes;
+import io.vlingo.xoom.common.Failure;
+import io.vlingo.xoom.reactivestreams.Stream;
+import io.vlingo.xoom.symbio.Entry;
+import io.vlingo.xoom.symbio.Metadata;
+import io.vlingo.xoom.symbio.Source;
+import io.vlingo.xoom.symbio.store.QueryExpression;
+import io.vlingo.xoom.symbio.store.Result;
+import io.vlingo.xoom.symbio.store.StorageException;
+import io.vlingo.xoom.symbio.store.state.StateStore;
+import io.vlingo.xoom.symbio.store.state.StateStoreEntryReader;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class FailingStateStore implements StateStore {
+
+  private final StateStore delegate;
+  private final AtomicInteger readCount = new AtomicInteger(0);
+  private final AtomicInteger expectedReadFailures = new AtomicInteger(0);
+
+  public FailingStateStore(final StateStore delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public void read(final String id, final Class type, final ReadResultInterest interest, final Object object) {
+    if (readCount.incrementAndGet() > expectedReadFailures.get()) {
+      delegate.read(id, type, interest, object);
+    } else {
+      interest.readResultedIn(Failure.of(new StorageException(Result.NotFound, "Not found.")), id, null, -1, null, object);
+    }
+  }
+
+  @Override
+  public void readAll(final Collection collection, final ReadResultInterest interest, final Object object) {
+    readCount.incrementAndGet();
+    delegate.readAll(collection, interest, object);
+  }
+
+  @Override
+  public Completes<Stream> streamAllOf(final Class stateType) {
+    readCount.incrementAndGet();
+    return delegate.streamAllOf(stateType);
+  }
+
+  @Override
+  public Completes<Stream> streamSomeUsing(final QueryExpression query) {
+    readCount.incrementAndGet();
+    return delegate.streamSomeUsing(query);
+  }
+
+  @Override
+  public <ET extends Entry<?>> Completes<StateStoreEntryReader<ET>> entryReader(final String s) {
+    return delegate.entryReader(s);
+  }
+
+  @Override
+  public <S, C> void write(final String s, final S s1, final int i, final List<Source<C>> list, final Metadata metadata, final WriteResultInterest writeResultInterest, final Object o) {
+    delegate.write(s, s1, i, list, metadata, writeResultInterest, o);
+  }
+
+  public void expectReadFailures(final Integer count) {
+    expectedReadFailures.set(count);
+  }
+}

--- a/src/test/java/io/vlingo/xoom/schemata/query/SchemaQueriesTest.java
+++ b/src/test/java/io/vlingo/xoom/schemata/query/SchemaQueriesTest.java
@@ -1,0 +1,136 @@
+package io.vlingo.xoom.schemata.query;
+
+import io.vlingo.xoom.actors.World;
+import io.vlingo.xoom.actors.testkit.TestWorld;
+import io.vlingo.xoom.common.Completes;
+import io.vlingo.xoom.common.Outcome;
+import io.vlingo.xoom.lattice.model.stateful.StatefulTypeRegistry;
+import io.vlingo.xoom.schemata.Schemata;
+import io.vlingo.xoom.schemata.model.Category;
+import io.vlingo.xoom.schemata.model.Scope;
+import io.vlingo.xoom.schemata.query.view.NamedSchemaView;
+import io.vlingo.xoom.schemata.query.view.SchemaView;
+import io.vlingo.xoom.symbio.Source;
+import io.vlingo.xoom.symbio.store.Result;
+import io.vlingo.xoom.symbio.store.StorageException;
+import io.vlingo.xoom.symbio.store.dispatch.NoOpDispatcher;
+import io.vlingo.xoom.symbio.store.state.StateStore;
+import io.vlingo.xoom.symbio.store.state.inmemory.InMemoryStateStoreActor;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+
+public class SchemaQueriesTest {
+  private World world;
+  private FailingStateStore stateStore;
+  private SchemaQueries queries;
+
+  @Test
+  public void schemaReturnsTheSchemaIfFound() {
+    givenSchemaView("vlingo", "schemata-test", "io.vlingo.xoom.schemata", "SchemaDefined", "First schema", "My first schema");
+
+    Completes<SchemaView> query = queries.schema("vlingo", "schemata-test", "io.vlingo.xoom.schemata", "SchemaDefined");
+    SchemaView view = query.await(1000);
+
+    assertEquals("First schema", view.name());
+  }
+
+  @Test
+  public void schemaReturnsNullIfNotFound() {
+    Completes<SchemaView> query = queries.schema("vlingo", "schemata-test", "io.vlingo.xoom.schemata", "SchemaDefined");
+    SchemaView view = query.await(1000);
+
+    assertEquals(null, view);
+  }
+
+  @Test
+  public void schemaByNamesReturnsTheSchemaIfFound() {
+    givenNamedSchemaView("vlingo", "schemata-test", "io.vlingo.xoom.schemata", "SchemaDefined", "First schema", "My first schema");
+
+    Completes<NamedSchemaView> query = queries.schemaByNames("vlingo", "schemata-test", "io.vlingo.xoom.schemata", "SchemaDefined");
+    NamedSchemaView view = query.await(1000);
+
+    assertEquals("First schema", view.name());
+  }
+
+  @Test
+  public void schemaByNamesReturnsNullIfNotFound() {
+    Completes<NamedSchemaView> query = queries.schemaByNames("vlingo", "schemata-test", "io.vlingo.xoom.schemata", "SchemaDefined");
+    NamedSchemaView view = query.await(1000);
+
+    assertEquals(null, view);
+  }
+
+  @Test
+  public void schemaByNamesWithRetriesReturnsTheSchemaDespiteInitialFailures() {
+    givenNamedSchemaView("vlingo", "schemata-test", "io.vlingo.xoom.schemata", "SchemaDefined", "First schema", "My first schema");
+    givenStateReadFailures(3);
+
+    Completes<NamedSchemaView> query = queries.schemaByNamesWithRetries(
+            "vlingo",
+            "schemata-test",
+            "io.vlingo.xoom.schemata",
+            "SchemaDefined",
+            100,
+            3
+    );
+    NamedSchemaView view = query.await(1000);
+
+    assertEquals("First schema", view.name());
+  }
+
+  @Before
+  public void init() {
+    world = TestWorld.startWithDefaults("test-state-store-query").world();
+    stateStore = new FailingStateStore(world.actorFor(StateStore.class, InMemoryStateStoreActor.class, Arrays.asList(new NoOpDispatcher())));
+    queries = world.actorFor(SchemaQueries.class, SchemaQueriesActor.class, stateStore);
+    StatefulTypeRegistry.registerAll(world, stateStore, SchemaView.class);
+    StatefulTypeRegistry.registerAll(world, stateStore, NamedSchemaView.class);
+  }
+
+  @After
+  public void shutdown() {
+    if (world != null) {
+      world.terminate();
+    }
+  }
+
+  private void givenStateReadFailures(int failures) {
+    stateStore.expectReadFailures(failures);
+  }
+
+  private void givenNamedSchemaView(String organizationId, String unitId, String contextId, String schemaId, String name, String description) {
+    String reference = Arrays.asList(organizationId, unitId, contextId, schemaId).stream().collect(Collectors.joining(Schemata.ReferenceSeparator));
+    stateStore.write(
+            reference,
+            NamedSchemaView.with(
+                    reference,
+                    SchemaView.with(organizationId, unitId, contextId, schemaId, Category.Event, Scope.Public, name, description)
+            ),
+            1,
+            new NoOpWriteResultInterest()
+    );
+  }
+
+  private void givenSchemaView(String organizationId, String unitId, String contextId, String schemaId, String name, String description) {
+    String id = Arrays.asList(contextId, schemaId).stream().collect(Collectors.joining(Schemata.ReferenceSeparator));
+    stateStore.write(
+            id,
+            SchemaView.with(organizationId, unitId, contextId, schemaId, Category.Event, Scope.Public, name, description),
+            1,
+            new NoOpWriteResultInterest()
+    );
+  }
+
+  private class NoOpWriteResultInterest implements StateStore.WriteResultInterest {
+    @Override
+    public <S, C> void writeResultedIn(Outcome<StorageException, Result> outcome, String s, S s1, int i, List<Source<C>> list, Object o) {
+    }
+  }
+}


### PR DESCRIPTION
Replaces #177

I wasn't sure whether to hide retry parameters inside the query actor or pass it down from the resource. In the end, decided to go with the second option as it was useful to use lower values for these parameters in tests.