### PR TITLE
Revamp the docker image 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,27 +68,59 @@ jobs:
         run: rm -rf ~/.m2/repository/io/vlingo
 
   docker:
-    name: Publish Docker image
+    name: Build Docker image
     runs-on: ubuntu-latest
     needs: build
-    if: (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master') && github.repository_owner == 'vlingo'
 
     steps:
       - uses: actions/checkout@v2
+      - name: Determine the version
+        id: version
+        run: |
+          DOCKER_IMAGE=vlingo/xoom-schemata
+          VERSION=latest
+          TAGS="${DOCKER_IMAGE}:${VERSION}"
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+            TAGS="$TAGS,${DOCKER_IMAGE}:${VERSION}"
+          fi
+          echo ::set-output name=version::${VERSION}
+          echo ::set-output name=tags::${TAGS}
+          echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+          echo ::set-output name=push::${{ (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master') && github.repository_owner == 'vlingo' }}
+
       - uses: actions/download-artifact@v2
         with:
           name: JARs
           path: target/
-      - name: Build & Push
-        uses: docker/build-push-action@v1
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        if: steps.version.outputs.push == 'true'
+        uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-          repository: vlingo/xoom-schemata
-          tag_with_ref: true
+
+      - name: Build & Push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: ${{ steps.version.outputs.push }}
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.version.outputs.tags }}
+          labels: |
+            org.opencontainers.image.source=${{ github.event.repository.html_url }}
+            org.opencontainers.image.created=${{ steps.version.outputs.created }}
+            org.opencontainers.image.revision=${{ github.sha }}
 
       - name: Notify slack
-        if: failure()
+        if: failure() && steps.version.outputs.push == 'true'
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_COLOR: "${{ job.status == 'success' && 'good' || 'danger' }}"
@@ -98,4 +130,4 @@ jobs:
           SLACK_ICON: 'https://vlingo.io/wp-content/uploads/cropped-vlingo-favicon-180x180.png'
           SLACK_FOOTER: '${{ github.repository }}'
           SLACK_TITLE: 'Docker Image'
-          SLACK_MESSAGE: ':rocket: ${{ needs.build.outputs.xoom_version }}'
+          SLACK_MESSAGE: ':rocket: ${{ steps.version.outputs.version }}'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,17 @@
-FROM openjdk:8-jdk-alpine
+FROM alpine:3.13
 
-ENV JAVA_OPTS=""
+LABEL maintainer="VLINGO XOOM Team <info@vlingo.io>"
+
+ENV JAVA_HOME=/usr/lib/jvm/default-jvm/
+ENV PATH=${JAVA_HOME}/bin:$PATH
 ENV XOOM_ENV="env"
 
-ADD ./target/xoom-schemata-*-jar-with-dependencies.jar /app.jar
+ADD ./target/xoom-schemata-*-jar-with-dependencies.jar /schemata/xoom-schemata.jar
 
-ENTRYPOINT exec java $JAVA_OPTS -Djava.security.egd=file:/dev/./urandom -jar /app.jar $XOOM_ENV
+RUN addgroup -S xoom && adduser -S -D -s /sbin/nologin -h /schemata -G xoom xoom \
+ && apk add --no-cache bash openjdk8 \
+ && chown -R xoom:xoom /schemata
+
+WORKDIR /schemata
+CMD java -jar /schemata/xoom-schemata.jar $XOOM_ENV
+USER xoom

--- a/README.md
+++ b/README.md
@@ -12,6 +12,17 @@ The VLINGO XOOM Schema Registry.
 
 ## Quick Start
 
+### Docker
+
+The quickest way to run XOOM Schemata is to use the [docker image](https://hub.docker.com/r/vlingo/xoom-schemata)
+published by the VLINGO XOOM Team:
+
+```bash
+docker run -it --rm -eXOOM_ENV=dev -p '9019:9019' vlingo/xoom-schemata
+```
+
+### Maven
+
 :warning: Make sure you are using a Java 8 JDK.
 
 Build <pre><code>& "<b>{yourInstallPath}</b>\xoom-schemata\mvnw.cmd" clean package -Pfrontend -f "<b>{yourInstallPath}</b>\xoom-schemata\pom.xml"</code></pre>
@@ -40,9 +51,9 @@ The maven build takes care of the following:
 * Run the UI build (`npm run export` in `src/main/frontend`) [Maven Profile 'frontend']
 * Package the backend, frontend and dependencies within a fat jar
 
-#### Docker Build:
-After building, you can optionally build the docker container with `docker build . -t vlingo/xoom-schemata`.
+#### Docker Build
 
+After building, you can optionally build the docker container with `docker build . -t vlingo/xoom-schemata`.
 
 ### Run
 


### PR DESCRIPTION
## Base the docker image on alpine directly

Currently, we use an outdated version of java 8.

From the OpenJDK team:

> The OpenJDK port for Alpine is not in a supported release by OpenJDK, since it is not in the mainline code base. It is only available as early access builds of OpenJDK Project Portola. See also [this comment](https://github.com/docker-library/openjdk/pull/235#issuecomment-424599754). So this image follows what is available from the OpenJDK project's maintainers.
>
> What this means is that Alpine based images are only released for early access release versions of OpenJDK. Once a particular release becomes a "General-Availability" release, the Alpine version is dropped from the "Supported Tags"; they are still available to pull, but will no longer be updated.

## Implement multi-arch builds

* amd64
* arm64 (Apple M1)
