### PR TITLE
Fix schema definitons with complex type references

### DIFF
--- a/src/main/antlr4/io/vlingo/xoom/schemata/codegen/antlr/SchemaVersionDefinitionLexer.g4
+++ b/src/main/antlr4/io/vlingo/xoom/schemata/codegen/antlr/SchemaVersionDefinitionLexer.g4
@@ -126,7 +126,7 @@ NULL_LITERAL
 
 
 TYPE_IDENTIFIER
-  : CapitalLetter LetterOrDigit* (COLON IDENTIFIER)* (COLON SEMANTIC_VERSION)?
+  : CapitalLetter LetterOrDigit*
   ;
 
 SEMANTIC_VERSION

--- a/src/main/antlr4/io/vlingo/xoom/schemata/codegen/antlr/SchemaVersionDefinitionParser.g4
+++ b/src/main/antlr4/io/vlingo/xoom/schemata/codegen/antlr/SchemaVersionDefinitionParser.g4
@@ -30,6 +30,10 @@ typeBody
   : LBRACE attributes RBRACE
   ;
 
+categoryTypeReference
+  : type DOT typeName
+  ;
+
 attributes
   : attribute*
   ;
@@ -62,8 +66,8 @@ basicTypeAttribute
   ;
 
 complexTypeAttribute
-  : typeName IDENTIFIER (ASSIGN NULL_LITERAL)?
-  | typeName ARRAY IDENTIFIER
+  : categoryTypeReference (COLON SEMANTIC_VERSION)? IDENTIFIER (ASSIGN NULL_LITERAL)?
+  | categoryTypeReference (COLON SEMANTIC_VERSION)? ARRAY IDENTIFIER
   ;
 
 specialTypeAttribute

--- a/src/main/java/io/vlingo/xoom/schemata/codegen/ast/types/ComplexType.java
+++ b/src/main/java/io/vlingo/xoom/schemata/codegen/ast/types/ComplexType.java
@@ -1,0 +1,42 @@
+package io.vlingo.xoom.schemata.codegen.ast.types;
+
+import io.vlingo.xoom.schemata.model.Category;
+
+import java.util.Objects;
+
+public class ComplexType implements Type {
+  public final Category category;
+  public final String typeName;
+
+  public ComplexType(Category category, String typeName) {
+    this.category = category;
+    this.typeName = typeName;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    ComplexType complexType = (ComplexType) o;
+    return category == complexType.category && Objects.equals(typeName, complexType.typeName);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(category, typeName);
+  }
+
+  @Override
+  public String name() {
+    return typeName;
+  }
+
+  public boolean isArrayType() {
+    return false;
+  }
+
+  @Override
+  public String toString() {
+    return "ComplexType [category=" + category + ", typeName=" + typeName + "]";
+  }
+}

--- a/src/main/java/io/vlingo/xoom/schemata/codegen/parser/AntlrTypeParser.java
+++ b/src/main/java/io/vlingo/xoom/schemata/codegen/parser/AntlrTypeParser.java
@@ -7,7 +7,27 @@
 
 package io.vlingo.xoom.schemata.codegen.parser;
 
-import static java.util.stream.Collectors.toList;
+import io.vlingo.xoom.common.Failure;
+import io.vlingo.xoom.common.Outcome;
+import io.vlingo.xoom.common.Success;
+import io.vlingo.xoom.schemata.codegen.antlr.SchemaVersionDefinitionLexer;
+import io.vlingo.xoom.schemata.codegen.antlr.SchemaVersionDefinitionParser;
+import io.vlingo.xoom.schemata.codegen.ast.FieldDefinition;
+import io.vlingo.xoom.schemata.codegen.ast.Node;
+import io.vlingo.xoom.schemata.codegen.ast.types.BasicArrayType;
+import io.vlingo.xoom.schemata.codegen.ast.types.BasicType;
+import io.vlingo.xoom.schemata.codegen.ast.types.ComplexType;
+import io.vlingo.xoom.schemata.codegen.ast.types.TypeDefinition;
+import io.vlingo.xoom.schemata.codegen.ast.values.ListValue;
+import io.vlingo.xoom.schemata.codegen.ast.values.NullValue;
+import io.vlingo.xoom.schemata.codegen.ast.values.SingleValue;
+import io.vlingo.xoom.schemata.codegen.ast.values.Value;
+import io.vlingo.xoom.schemata.errors.SchemataBusinessException;
+import io.vlingo.xoom.schemata.model.Category;
+import org.antlr.v4.runtime.CodePointBuffer;
+import org.antlr.v4.runtime.CodePointCharStream;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.tree.TerminalNode;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -19,27 +39,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import org.antlr.v4.runtime.CodePointBuffer;
-import org.antlr.v4.runtime.CodePointCharStream;
-import org.antlr.v4.runtime.CommonTokenStream;
-import org.antlr.v4.runtime.tree.TerminalNode;
-
-import io.vlingo.xoom.common.Failure;
-import io.vlingo.xoom.common.Outcome;
-import io.vlingo.xoom.common.Success;
-import io.vlingo.xoom.schemata.codegen.antlr.SchemaVersionDefinitionLexer;
-import io.vlingo.xoom.schemata.codegen.antlr.SchemaVersionDefinitionParser;
-import io.vlingo.xoom.schemata.codegen.ast.FieldDefinition;
-import io.vlingo.xoom.schemata.codegen.ast.Node;
-import io.vlingo.xoom.schemata.codegen.ast.types.BasicArrayType;
-import io.vlingo.xoom.schemata.codegen.ast.types.BasicType;
-import io.vlingo.xoom.schemata.codegen.ast.types.TypeDefinition;
-import io.vlingo.xoom.schemata.codegen.ast.values.ListValue;
-import io.vlingo.xoom.schemata.codegen.ast.values.NullValue;
-import io.vlingo.xoom.schemata.codegen.ast.values.SingleValue;
-import io.vlingo.xoom.schemata.codegen.ast.values.Value;
-import io.vlingo.xoom.schemata.errors.SchemataBusinessException;
-import io.vlingo.xoom.schemata.model.Category;
+import static java.util.stream.Collectors.toList;
 
 
 public class AntlrTypeParser implements TypeParser {
@@ -155,10 +155,11 @@ public class AntlrTypeParser implements TypeParser {
     }
 
     private Node parseComplexTypeAttribute(SchemaVersionDefinitionParser.ComplexTypeAttributeContext attribute) {
-        String typeName = attribute.typeName().getText();
+        String typeName = attribute.categoryTypeReference().typeName().getText();
+        Category category = categoryOf(attribute.categoryTypeReference().type().getText());
         String fieldName = attribute.IDENTIFIER().getText();
 
-        return new FieldDefinition(new BasicType(typeName), Optional.empty(), fieldName, Optional.empty());
+        return new FieldDefinition(new ComplexType(category, typeName), Optional.empty(), fieldName, Optional.empty());
     }
 
     private Node parseSpecialTypeAttribute(SchemaVersionDefinitionParser.SpecialTypeAttributeContext attribute) {

--- a/src/test/java/io/vlingo/xoom/schemata/codegen/specs/JavaCodeGenTests.java
+++ b/src/test/java/io/vlingo/xoom/schemata/codegen/specs/JavaCodeGenTests.java
@@ -8,14 +8,7 @@
 package io.vlingo.xoom.schemata.codegen.specs;
 
 import io.vlingo.xoom.codegen.TextExpectation;
-import io.vlingo.xoom.schemata.codegen.CodeGenTests;
-import io.vlingo.xoom.schemata.codegen.TypeDefinitionCompiler;
 import io.vlingo.xoom.schemata.codegen.TypeDefinitionCompilerActor;
-import io.vlingo.xoom.schemata.errors.SchemataBusinessException;
-import org.junit.Test;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 
 public class JavaCodeGenTests extends CodeGenSpecs {
   @Override

--- a/src/test/resources/io/vlingo/xoom/schemata/codegen/vss/price-changed.vss
+++ b/src/test/resources/io/vlingo/xoom/schemata/codegen/vss/price-changed.vss
@@ -1,6 +1,6 @@
 event PriceChanged {
     version eventVersion
     timestamp occurredOn
-    Org:Unit:Context:Schema:Price oldPrice
-    Org:Unit:Context:Schema:Price:1.0.0 newPrice
+    data.Price oldPrice
+    data.Price:1.0.0 newPrice
 }


### PR DESCRIPTION
Re #183
Replaces #191

* The type identifier only allows for letters and digits
* The complex type attributes can only be made of category type references (i.e. `data.Price`).
* The category is currently not validated (i.e. `data.Price` could actually be referenced as `event.Price`).
* One of the tests that used to use fully qualified type names was updated to use category type references.  Fully qualified type references are no longer supported.
* Arrays of complex types are currently not supported (never were). I'll add it in a separate PR.
* The version in type reference doesn't seem to have any effect. Something for a separate PR too.