### PR TITLE
Generate command types

### DIFF
--- a/src/main/java/io/vlingo/xoom/schemata/codegen/template/schematype/SchemaTypePackage.java
+++ b/src/main/java/io/vlingo/xoom/schemata/codegen/template/schematype/SchemaTypePackage.java
@@ -44,6 +44,10 @@ public class SchemaTypePackage {
     return new SchemaTypePackage(this.packageSegments, this.separator, formatter);
   }
 
+  public SchemaTypePackage withTitleCaseSegmentFormatter() {
+    return this.withSegmentFormatter((segment) -> segment.substring(0, 1).toUpperCase() + segment.substring(1));
+  }
+
   public String name() {
     return packageSegments.stream().map(segmentFormatter).collect(joining(separator));
   }

--- a/src/main/java/io/vlingo/xoom/schemata/codegen/template/schematype/csharp/CSharpSchemaTypeTemplateData.java
+++ b/src/main/java/io/vlingo/xoom/schemata/codegen/template/schematype/csharp/CSharpSchemaTypeTemplateData.java
@@ -41,7 +41,7 @@ public class CSharpSchemaTypeTemplateData extends SchemaTypeTemplateData {
 
   private String namespace() {
     return SchemaTypePackage.from(type.fullyQualifiedTypeName, categoryNamespaceSegment(type.category), ".")
-            .withSegmentFormatter((segment) -> segment.substring(0, 1).toUpperCase() + segment.substring(1))
+            .withTitleCaseSegmentFormatter()
             .name();
   }
 
@@ -58,7 +58,7 @@ public class CSharpSchemaTypeTemplateData extends SchemaTypeTemplateData {
     final Stream<String> propertyImports = properties.stream().flatMap(p -> p.namespaceImports.stream());
     final boolean usesSystem = properties.stream().anyMatch(p -> p.constructorInitializer.startsWith("DateTimeOffset."));
     final boolean usesVersion = properties.stream().anyMatch(p -> p.constructorInitializer.startsWith("SemanticVersion."));
-    final boolean usesLatticeModel = type.category.equals(Category.Event);
+    final boolean usesLatticeModel = type.category.equals(Category.Event) || type.category.equals(Category.Command);
     return Stream.concat(Stream.of("System", "Vlingo.Lattice.Model", "Vlingo.Xoom.Common.Version"), propertyImports)
             .filter(i -> !(i.equals("System") && !usesSystem))
             .filter(i -> !(i.equals("Vlingo.Xoom.Common.Version") && !usesVersion))
@@ -75,6 +75,8 @@ public class CSharpSchemaTypeTemplateData extends SchemaTypeTemplateData {
     switch (type.category) {
       case Event:
         return "DomainEvent";
+      case Command:
+        return "Command";
       default:
         return null;
     }

--- a/src/main/java/io/vlingo/xoom/schemata/codegen/template/schematype/csharp/CSharpType.java
+++ b/src/main/java/io/vlingo/xoom/schemata/codegen/template/schematype/csharp/CSharpType.java
@@ -37,7 +37,11 @@ public class CSharpType {
       return CSharpType.from(((ArrayType) type).elementType, owner).namespaceImports();
     }
     if (type instanceof ComplexType) {
-      return Arrays.asList(SchemaTypePackage.from(owner.fullyQualifiedTypeName, ((ComplexType) type).category.name(), ".").name());
+      return Arrays.asList(
+              SchemaTypePackage.from(owner.fullyQualifiedTypeName, ((ComplexType) type).category.name(), ".")
+                      .withTitleCaseSegmentFormatter()
+                      .name()
+      );
     }
     return Arrays.asList();
   }

--- a/src/main/java/io/vlingo/xoom/schemata/codegen/template/schematype/java/JavaSchemaTypeTemplateData.java
+++ b/src/main/java/io/vlingo/xoom/schemata/codegen/template/schematype/java/JavaSchemaTypeTemplateData.java
@@ -2,6 +2,7 @@ package io.vlingo.xoom.schemata.codegen.template.schematype.java;
 
 import io.vlingo.xoom.codegen.template.TemplateData;
 import io.vlingo.xoom.codegen.template.TemplateParameters;
+import io.vlingo.xoom.lattice.model.Command;
 import io.vlingo.xoom.lattice.model.DomainEvent;
 import io.vlingo.xoom.schemata.codegen.ast.FieldDefinition;
 import io.vlingo.xoom.schemata.codegen.ast.types.TypeDefinition;
@@ -73,6 +74,8 @@ public class JavaSchemaTypeTemplateData extends SchemaTypeTemplateData {
     switch (type.category) {
       case Event:
         return Optional.of(DomainEvent.class);
+      case Command:
+        return Optional.of(Command.class);
       default:
         return Optional.empty();
     }

--- a/src/test/java/io/vlingo/xoom/schemata/codegen/specs/CodeGenSpecs.java
+++ b/src/test/java/io/vlingo/xoom/schemata/codegen/specs/CodeGenSpecs.java
@@ -112,4 +112,12 @@ abstract public class CodeGenSpecs extends CodeGenTests {
 
     assertMatchesSpec(result, "types/price");
   }
+
+  @Test
+  public void testThatItGeneratesCommandTypes() throws SchemataBusinessException {
+    registerType("types/price", "Vlingo:Xoom:io.vlingo.xoom.examples:Command:Price", "1.0.0");
+    final String result = compileSpecAndUnwrap(typeDefinition("command"), "Vlingo:Xoom:io.vlingo.xoom.examples:Command:ChangePrice", "1.0.0");
+
+    assertMatchesSpec(result, "command");
+  }
 }

--- a/src/test/resources/io/vlingo/xoom/schemata/codegen/vss/command.vss
+++ b/src/test/resources/io/vlingo/xoom/schemata/codegen/vss/command.vss
@@ -1,0 +1,4 @@
+command ChangePrice {
+    data.Price oldPrice
+    data.Price:1.0.0 newPrice
+}

--- a/src/test/resources/text-expectations/c_sharp/command.text
+++ b/src/test/resources/text-expectations/c_sharp/command.text
@@ -1,0 +1,17 @@
+using Io.Vlingo.Xoom.Examples.Data;
+using Vlingo.Lattice.Model;
+
+namespace Io.Vlingo.Xoom.Examples.Commands
+{
+  public sealed class ChangePrice : Command
+  {
+    public Price OldPrice { get; }
+
+    public Price NewPrice { get; }
+
+    public ChangePrice(Price oldPrice, Price newPrice) {
+      OldPrice = oldPrice;
+      NewPrice = newPrice;
+    }
+  }
+}

--- a/src/test/resources/text-expectations/java/command.text
+++ b/src/test/resources/text-expectations/java/command.text
@@ -1,0 +1,15 @@
+package io.vlingo.xoom.examples.command;
+
+import io.vlingo.xoom.examples.data.Price;
+import io.vlingo.xoom.lattice.model.Command;
+
+public final class ChangePrice extends Command {
+  public final Price oldPrice;
+
+  public final Price newPrice;
+
+  public ChangePrice(final Price oldPrice, final Price newPrice) {
+    this.oldPrice = oldPrice;
+    this.newPrice = newPrice;
+  }
+}


### PR DESCRIPTION
Example:

```
command ChangePrice {
    data.Price oldPrice
    data.Price:1.0.0 newPrice
}
```

Java

```java
package io.vlingo.xoom.examples.command;

import io.vlingo.xoom.examples.data.Price;
import io.vlingo.xoom.lattice.model.Command;

public final class ChangePrice extends Command {
  public final Price oldPrice;

  public final Price newPrice;

  public ChangePrice(final Price oldPrice, final Price newPrice) {
    this.oldPrice = oldPrice;
    this.newPrice = newPrice;
  }
}
```

C#

```csharp
using Io.Vlingo.Xoom.Examples.Data;
using Vlingo.Lattice.Model;

namespace Io.Vlingo.Xoom.Examples.Commands
{
  public sealed class ChangePrice : Command
  {
    public Price OldPrice { get; }

    public Price NewPrice { get; }

    public ChangePrice(Price oldPrice, Price newPrice) {
      OldPrice = oldPrice;
      NewPrice = newPrice;
    }
  }
}
```