### PR TITLE
Testing projections

### DIFF
--- a/src/main/java/io/vlingo/xoom/schemata/query/view/OrganizationView.java
+++ b/src/main/java/io/vlingo/xoom/schemata/query/view/OrganizationView.java
@@ -90,7 +90,7 @@ public class OrganizationView {
     }
 
     public OrganizationView mergeWith(String organizationId, String name, String description) {
-        if (this.description.equals(organizationId)) {
+        if (this.organizationId.equals(organizationId)) {
             return new OrganizationView(organizationId, name, description);
         } else {
             return this;

--- a/src/main/java/io/vlingo/xoom/schemata/query/view/UnitView.java
+++ b/src/main/java/io/vlingo/xoom/schemata/query/view/UnitView.java
@@ -83,7 +83,7 @@ public class UnitView {
 
     public UnitView mergeDescriptionWith(String unitId, String description) {
         if (this.unitId.equals(unitId)) {
-            return new UnitView(this.unitId, this.name, this.description);
+            return new UnitView(this.unitId, this.name, description);
         } else {
             return this;
         }

--- a/src/test/java/io/vlingo/xoom/schemata/infra/persistence/CodeProjectionTest.java
+++ b/src/test/java/io/vlingo/xoom/schemata/infra/persistence/CodeProjectionTest.java
@@ -1,9 +1,9 @@
 package io.vlingo.xoom.schemata.infra.persistence;
 
+import io.vlingo.xoom.common.Completes;
 import io.vlingo.xoom.schemata.model.Path;
 import io.vlingo.xoom.schemata.model.SchemaVersion;
 import io.vlingo.xoom.schemata.model.SchemaVersion.Specification;
-import io.vlingo.xoom.schemata.query.CodeQueries;
 import io.vlingo.xoom.schemata.query.view.CodeView;
 import org.junit.Test;
 
@@ -12,7 +12,6 @@ import static io.vlingo.xoom.schemata.test.Assertions.assertCompletes;
 import static org.junit.Assert.assertEquals;
 
 public class CodeProjectionTest extends ProjectionTest {
-  private CodeQueries codeQueries;
 
   @Test
   public void itProjectsCodeViewFromSchemaVersionDefinedEvents() {
@@ -30,7 +29,7 @@ public class CodeProjectionTest extends ProjectionTest {
 
     final Path reference = Path.with(OrgName, UnitName, ContextNamespace, SchemaName, SchemaVersionVersion100.value);
 
-    assertCompletes(codeQueries.codeFor(reference), (codeView) -> {
+    assertCompletes(codeView(reference), (codeView) -> {
       assertEquals(SchemaVersionVersion100.value, codeView.currentVersion());
       assertEquals(SchemaVersionSpecification.value, codeView.specification());
     });
@@ -54,16 +53,13 @@ public class CodeProjectionTest extends ProjectionTest {
 
     final Path reference = Path.with(OrgName, UnitName, ContextNamespace, SchemaName, SchemaVersionVersion101.value);
 
-    assertCompletes(codeQueries.codeFor(reference), (codeView) -> {
+    assertCompletes(codeView(reference), (codeView) -> {
       assertEquals(SchemaVersionVersion101.value, codeView.currentVersion());
       assertEquals(updatedSchemaSpecification.value, codeView.specification());
     });
   }
 
-  @Override
-  public void setUp() throws Exception {
-    super.setUp();
-
-    codeQueries = StorageProvider.instance().codeQueries;
+  private Completes<CodeView> codeView(Path reference) {
+    return StorageProvider.instance().codeQueries.codeFor(reference);
   }
 }

--- a/src/test/java/io/vlingo/xoom/schemata/infra/persistence/CodeProjectionTest.java
+++ b/src/test/java/io/vlingo/xoom/schemata/infra/persistence/CodeProjectionTest.java
@@ -1,0 +1,69 @@
+package io.vlingo.xoom.schemata.infra.persistence;
+
+import io.vlingo.xoom.schemata.model.Path;
+import io.vlingo.xoom.schemata.model.SchemaVersion;
+import io.vlingo.xoom.schemata.model.SchemaVersion.Specification;
+import io.vlingo.xoom.schemata.query.CodeQueries;
+import io.vlingo.xoom.schemata.query.view.CodeView;
+import org.junit.Test;
+
+import static io.vlingo.xoom.schemata.infra.persistence.Fixtures.*;
+import static io.vlingo.xoom.schemata.test.Assertions.assertCompletes;
+import static org.junit.Assert.assertEquals;
+
+public class CodeProjectionTest extends ProjectionTest {
+  private CodeQueries codeQueries;
+
+  @Test
+  public void itProjectsCodeViewFromSchemaVersionDefinedEvents() {
+
+    onceProjected(CodeView.class, () -> givenAnySchema()
+            .andThenTo(schema -> SchemaVersion.with(
+                    stage,
+                    schema.schemaId,
+                    SchemaVersionSpecification,
+                    SchemaVersionDescription,
+                    SchemaVersionVersion000,
+                    SchemaVersionVersion100
+            ))
+    );
+
+    final Path reference = Path.with(OrgName, UnitName, ContextNamespace, SchemaName, SchemaVersionVersion100.value);
+
+    assertCompletes(codeQueries.codeFor(reference), (codeView) -> {
+      assertEquals(SchemaVersionVersion100.value, codeView.currentVersion());
+      assertEquals(SchemaVersionSpecification.value, codeView.specification());
+    });
+  }
+
+  @Test
+  public void itUpdatesCodeViewFromSchemaVersionDefinedEvents() {
+
+    final Specification updatedSchemaSpecification = Specification.of("event SchemaDefined { type eventType }");
+
+    onceProjected(CodeView.class, () -> givenAnySchemaVersion()
+            .andThenTo(schemaVersion -> SchemaVersion.with(
+                    stage,
+                    schemaVersion.schemaVersionId.schemaId,
+                    updatedSchemaSpecification,
+                    "Updated description",
+                    schemaVersion.currentVersion,
+                    SchemaVersionVersion101
+            ))
+    );
+
+    final Path reference = Path.with(OrgName, UnitName, ContextNamespace, SchemaName, SchemaVersionVersion101.value);
+
+    assertCompletes(codeQueries.codeFor(reference), (codeView) -> {
+      assertEquals(SchemaVersionVersion101.value, codeView.currentVersion());
+      assertEquals(updatedSchemaSpecification.value, codeView.specification());
+    });
+  }
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+
+    codeQueries = StorageProvider.instance().codeQueries;
+  }
+}

--- a/src/test/java/io/vlingo/xoom/schemata/infra/persistence/ContextProjectionTest.java
+++ b/src/test/java/io/vlingo/xoom/schemata/infra/persistence/ContextProjectionTest.java
@@ -1,0 +1,90 @@
+package io.vlingo.xoom.schemata.infra.persistence;
+
+import io.vlingo.xoom.common.Completes;
+import io.vlingo.xoom.schemata.model.Context;
+import io.vlingo.xoom.schemata.model.ContextEntity;
+import io.vlingo.xoom.schemata.model.ContextState;
+import io.vlingo.xoom.schemata.model.Id.ContextId;
+import io.vlingo.xoom.schemata.query.view.ContextView;
+import org.junit.Test;
+
+import static io.vlingo.xoom.schemata.infra.persistence.Fixtures.ContextDescription;
+import static io.vlingo.xoom.schemata.infra.persistence.Fixtures.ContextNamespace;
+import static io.vlingo.xoom.schemata.test.Assertions.assertCompletes;
+import static org.junit.Assert.assertEquals;
+
+public class ContextProjectionTest extends ProjectionTest {
+
+  @Test
+  public void itCreatesTheContextViewOnContextDefinedEvent() {
+
+    final Completes<ContextState> contextState = onceProjected(ContextView.class, () -> givenAnyUnit()
+            .andThenTo(u -> Context.with(
+                    stage,
+                    u.unitId,
+                    ContextNamespace,
+                    ContextDescription
+            ))
+    );
+    final Completes<ContextView> contextView = contextState.andThenTo(this::contextView);
+
+    assertCompletes(contextView, (context) -> {
+      assertEquals(ContextNamespace, context.namespace());
+      assertEquals(ContextDescription, context.description());
+    });
+  }
+
+  @Test
+  public void itRedefinesTheContextViewOnContextRedefinedEvent() {
+
+    final Completes<ContextState> contextState = onceProjected(ContextView.class, () -> givenAnyContext()
+            .andThenTo(state -> context(state.contextId)
+                    .redefineWith("io.vlingo.xoom.schemata.new", "XOOM Schemata")
+            )
+    );
+    final Completes<ContextView> contextView = contextState.andThenTo(this::contextView);
+
+    assertCompletes(contextView, (context) -> {
+      assertEquals("io.vlingo.xoom.schemata.new", context.namespace());
+      assertEquals("XOOM Schemata", context.description());
+    });
+  }
+
+  @Test
+  public void itMovesContextViewNamespaceOnContextMovedToNamespaceEvent() {
+
+    final Completes<ContextState> contextState = onceProjected(ContextView.class, () -> givenAnyContext()
+            .andThenTo(state -> context(state.contextId)
+                    .moveToNamespace("io.vlingo.xoom.schemata.new")
+            )
+    );
+    final Completes<ContextView> contextView = contextState.andThenTo(this::contextView);
+
+    assertCompletes(contextView, (context) -> assertEquals("io.vlingo.xoom.schemata.new", context.namespace()));
+  }
+
+  @Test
+  public void itUpdatesDescriptionOnContextDescribedEvent() {
+
+    final Completes<ContextState> contextState = onceProjected(ContextView.class, () -> givenAnyContext()
+            .andThenTo(state -> context(state.contextId)
+                    .describeAs("XOOM Team")
+            )
+    );
+    final Completes<ContextView> contextView = contextState.andThenTo(this::contextView);
+
+    assertCompletes(contextView, (context) -> assertEquals("XOOM Team", context.description()));
+  }
+
+  private Context context(ContextId contextId) {
+    return stage.actorFor(Context.class, ContextEntity.class, contextId);
+  }
+
+  private Completes<ContextView> contextView(ContextState state) {
+    return StorageProvider.instance().contextQueries.context(
+            state.contextId.organizationId().value,
+            state.contextId.unitId.value,
+            state.contextId.value
+    );
+  }
+}

--- a/src/test/java/io/vlingo/xoom/schemata/infra/persistence/ContextsProjectionTest.java
+++ b/src/test/java/io/vlingo/xoom/schemata/infra/persistence/ContextsProjectionTest.java
@@ -1,0 +1,77 @@
+package io.vlingo.xoom.schemata.infra.persistence;
+
+import io.vlingo.xoom.common.Completes;
+import io.vlingo.xoom.schemata.model.Context;
+import io.vlingo.xoom.schemata.model.ContextEntity;
+import io.vlingo.xoom.schemata.model.ContextState;
+import io.vlingo.xoom.schemata.model.Id.ContextId;
+import io.vlingo.xoom.schemata.model.Id.UnitId;
+import io.vlingo.xoom.schemata.query.view.ContextsView;
+import io.vlingo.xoom.schemata.query.view.ContextsView.ContextItem;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static io.vlingo.xoom.schemata.test.Assertions.assertCompletes;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class ContextsProjectionTest extends ProjectionTest {
+
+  @Test
+  public void itCreatesTheContextsViewOnUnitDefineEvent() {
+    final Completes<ContextsView> contextsView = givenAnyUnit().andThenTo(unit -> contextsView(unit.unitId));
+
+    assertCompletes(contextsView, (contexts) -> assertEquals(Collections.emptyList(), contexts.all()));
+  }
+
+  @Test
+  public void itAddsContextItemOnContextDefinedEvent() {
+    final Completes<ContextState> contextState = givenAnyContext();
+    final Completes<ContextsView> contextsView = contextState.andThenTo(context -> contextsView(context.contextId.unitId));
+    final ContextId contextId = contextState.andThen(context -> context.contextId).await();
+
+    assertCompletes(contextsView, (contexts) -> {
+      final ContextItem contextItem = contexts.get(contextId.value);
+      assertNotNull(contextItem);
+      assertEquals(Fixtures.ContextNamespace, contextItem.namespace);
+      assertEquals(Fixtures.ContextDescription, contextItem.description);
+    });
+  }
+
+  @Test
+  public void itReplacesContextItemOnContextRedefinedEvent() {
+    final Completes<ContextState> contextState = onceProjected(ContextsView.class, () -> givenAnyContext()
+            .andThenTo(context -> context(context.contextId).redefineWith(context.namespace, "XOOM Schemata")));
+    final Completes<ContextsView> contextView = contextState.andThenTo(context -> contextsView(context.contextId.unitId));
+    final ContextId contextId = contextState.andThen(context -> context.contextId).await();
+
+    assertCompletes(contextView, (contexts) -> {
+      final ContextItem contextItem = contexts.get(contextId.value);
+      assertNotNull(contextItem);
+      assertEquals("XOOM Schemata", contextItem.description);
+    });
+  }
+
+  @Test
+  public void itReplacesContextItemOnContextMovedToNamespaceEvent() {
+    final Completes<ContextState> contextState = onceProjected(ContextsView.class, () -> givenAnyContext()
+            .andThenTo(context -> context(context.contextId).moveToNamespace("io.vlingo.xoom.schemata.new")));
+    final Completes<ContextsView> contextView = contextState.andThenTo(context -> contextsView(context.contextId.unitId));
+    final ContextId contextId = contextState.andThen(context -> context.contextId).await();
+
+    assertCompletes(contextView, (contexts) -> {
+      final ContextItem contextItem = contexts.get(contextId.value);
+      assertNotNull(contextItem);
+      assertEquals("io.vlingo.xoom.schemata.new", contextItem.namespace);
+    });
+  }
+
+  private Context context(ContextId contextId) {
+    return stage.actorFor(Context.class, ContextEntity.class, contextId);
+  }
+
+  private Completes<ContextsView> contextsView(UnitId unitId) {
+    return StorageProvider.instance().contextQueries.contexts(unitId.organizationId.value, unitId.value);
+  }
+}

--- a/src/test/java/io/vlingo/xoom/schemata/infra/persistence/Fixtures.java
+++ b/src/test/java/io/vlingo/xoom/schemata/infra/persistence/Fixtures.java
@@ -1,0 +1,25 @@
+package io.vlingo.xoom.schemata.infra.persistence;
+
+import io.vlingo.xoom.schemata.model.Category;
+import io.vlingo.xoom.schemata.model.Scope;
+
+import static io.vlingo.xoom.schemata.model.SchemaVersion.Specification;
+import static io.vlingo.xoom.schemata.model.SchemaVersion.Version;
+
+class Fixtures {
+  public static final String OrgName = "VLINGO, LLC";
+  public static final String OrgDescription = "We are the VLINGO XOOM Platform company.";
+  public static final String UnitName = "Development Team";
+  public static final String UnitDescription = "We are VLINGO XOOM Platform development.";
+  public static final String ContextNamespace = "io.vlingo.xoom.schemata";
+  public static final String ContextDescription = "We are the VLINGO XOOM Scehmata team.";
+  public static final String SchemaName = "SchemaDefined";
+  public static final String SchemaDescription = "Captures that a schema's definition occurred.";
+  public static final Category SchemaCategory = Category.Event;
+  public static final Scope SchemaScope = Scope.Public;
+  public static final String SchemaVersionDescription = "Test context.";
+  public static final Specification SchemaVersionSpecification = Specification.of("event SchemaDefined {}");
+  public static final Version SchemaVersionVersion000 = Version.of("0.0.0");
+  public static final Version SchemaVersionVersion100 = Version.of("1.0.0");
+  public static final Version SchemaVersionVersion101 = Version.of("1.0.1");
+}

--- a/src/test/java/io/vlingo/xoom/schemata/infra/persistence/NamedSchemaProjectionTest.java
+++ b/src/test/java/io/vlingo/xoom/schemata/infra/persistence/NamedSchemaProjectionTest.java
@@ -1,0 +1,46 @@
+package io.vlingo.xoom.schemata.infra.persistence;
+
+import io.vlingo.xoom.common.Completes;
+import io.vlingo.xoom.schemata.model.SchemaState;
+import io.vlingo.xoom.schemata.model.SchemaVersionState;
+import io.vlingo.xoom.schemata.query.view.NamedSchemaView;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static io.vlingo.xoom.schemata.test.Assertions.assertCompletes;
+import static org.junit.Assert.assertEquals;
+
+public class NamedSchemaProjectionTest extends ProjectionTest {
+
+  @Test
+  public void itCreatesNamedSchemaViewOnSchemaDefinedEvent() {
+    Completes<SchemaState> schemaState = givenAnySchema();
+    Completes<NamedSchemaView> schemaView = schemaState.andThenTo(state -> namedSchemaView(
+            Fixtures.OrgName, Fixtures.UnitName, Fixtures.ContextNamespace, Fixtures.SchemaName
+    ));
+
+    assertCompletes(schemaView, (view) -> {
+      assertEquals(Fixtures.SchemaName, view.name());
+      assertEquals(Collections.emptyList(), view.schemaVersions());
+    });
+  }
+
+  @Test
+  public void itNamedSchemaViewWithSchemaVersionOnSchemaVersionDefinedEvent() {
+    Completes<SchemaVersionState> schemaVersionState = givenAnySchemaVersion();
+    Completes<NamedSchemaView> schemaView = schemaVersionState.andThenTo(state -> namedSchemaView(
+            Fixtures.OrgName, Fixtures.UnitName, Fixtures.ContextNamespace, Fixtures.SchemaName
+    ));
+
+    assertCompletes(schemaView, (view) -> {
+      assertEquals(1, view.schemaVersions().size());
+      assertEquals(Fixtures.SchemaVersionSpecification.value, view.schemaVersions().get(0).specification());
+    });
+  }
+
+  @SuppressWarnings("SameParameterValue")
+  private Completes<NamedSchemaView> namedSchemaView(final String orgName, final String unitName, final String contextNamespace, final String schemaName) {
+    return StorageProvider.instance().schemaQueries.schemaByNames(orgName, unitName, contextNamespace, schemaName);
+  }
+}

--- a/src/test/java/io/vlingo/xoom/schemata/infra/persistence/OrganizationProjectionTest.java
+++ b/src/test/java/io/vlingo/xoom/schemata/infra/persistence/OrganizationProjectionTest.java
@@ -1,0 +1,67 @@
+package io.vlingo.xoom.schemata.infra.persistence;
+
+import io.vlingo.xoom.common.Completes;
+import io.vlingo.xoom.schemata.model.Id.OrganizationId;
+import io.vlingo.xoom.schemata.model.Organization;
+import io.vlingo.xoom.schemata.model.OrganizationEntity;
+import io.vlingo.xoom.schemata.model.OrganizationState;
+import io.vlingo.xoom.schemata.query.view.OrganizationView;
+import org.junit.Test;
+
+import static io.vlingo.xoom.schemata.test.Assertions.assertCompletes;
+import static org.junit.Assert.assertEquals;
+
+public class OrganizationProjectionTest extends ProjectionTest {
+
+  @Test
+  public void itCreatesOrganizationViewOnOrganizationDefinedEvent() {
+    Completes<OrganizationView> view = givenAnyOrganization().andThenTo(state -> organizationView(state.organizationId));
+
+    assertCompletes(view, (organizationView -> {
+      assertEquals(Fixtures.OrgName, organizationView.name());
+      assertEquals(Fixtures.OrgDescription, organizationView.description());
+    }));
+  }
+
+  @Test
+  public void itUpdatesOrganizationDescriptionOnOrganizationDefinedEvent() {
+    Completes<OrganizationState> organizationState = onceProjected(OrganizationView.class, () -> givenAnyOrganization()
+            .andThenTo(state -> organization(state.organizationId).describeAs("New organization description")));
+    Completes<OrganizationView> view = organizationState.andThenTo(state -> organizationView(state.organizationId));
+
+    assertCompletes(view, (organizationView) -> {
+      assertEquals("New organization description", organizationView.description());
+    });
+  }
+
+  @Test
+  public void itUpdatesOrganizationNameOnOrganizationRenamedEvent() {
+    Completes<OrganizationState> organizationState = onceProjected(OrganizationView.class, () -> givenAnyOrganization()
+            .andThenTo(state -> organization(state.organizationId).renameTo("New VLINGO")));
+    Completes<OrganizationView> view = organizationState.andThenTo(state -> organizationView(state.organizationId));
+
+    assertCompletes(view, (organizationView) -> {
+      assertEquals("New VLINGO", organizationView.name());
+    });
+  }
+
+  @Test
+  public void itUpdatesOrganizationNameAndDescriptionOnOrganizationRedefinedEvent() {
+    Completes<OrganizationState> organizationState = onceProjected(OrganizationView.class, () -> givenAnyOrganization()
+            .andThenTo(state -> organization(state.organizationId).redefineWith("New VLINGO", "New description")));
+    Completes<OrganizationView> view = organizationState.andThenTo(state -> organizationView(state.organizationId));
+
+    assertCompletes(view, (organizationView) -> {
+      assertEquals("New VLINGO", organizationView.name());
+      assertEquals("New description", organizationView.description());
+    });
+  }
+
+  public Completes<OrganizationView> organizationView(OrganizationId organizationId) {
+    return StorageProvider.instance().organizationQueries.organization(organizationId.value);
+  }
+
+  public Organization organization(OrganizationId organizationId) {
+    return stage.actorFor(Organization.class, OrganizationEntity.class, organizationId);
+  }
+}

--- a/src/test/java/io/vlingo/xoom/schemata/infra/persistence/OrganizationProjectionTest.java
+++ b/src/test/java/io/vlingo/xoom/schemata/infra/persistence/OrganizationProjectionTest.java
@@ -24,14 +24,14 @@ public class OrganizationProjectionTest extends ProjectionTest {
   }
 
   @Test
-  public void itUpdatesOrganizationDescriptionOnOrganizationDefinedEvent() {
+  public void itUpdatesOrganizationDescriptionOnOrganizationDescribedEvent() {
     Completes<OrganizationState> organizationState = onceProjected(OrganizationView.class, () -> givenAnyOrganization()
             .andThenTo(state -> organization(state.organizationId).describeAs("New organization description")));
     Completes<OrganizationView> view = organizationState.andThenTo(state -> organizationView(state.organizationId));
 
-    assertCompletes(view, (organizationView) -> {
-      assertEquals("New organization description", organizationView.description());
-    });
+    assertCompletes(view, (organizationView) ->
+            assertEquals("New organization description", organizationView.description())
+    );
   }
 
   @Test
@@ -40,9 +40,7 @@ public class OrganizationProjectionTest extends ProjectionTest {
             .andThenTo(state -> organization(state.organizationId).renameTo("New VLINGO")));
     Completes<OrganizationView> view = organizationState.andThenTo(state -> organizationView(state.organizationId));
 
-    assertCompletes(view, (organizationView) -> {
-      assertEquals("New VLINGO", organizationView.name());
-    });
+    assertCompletes(view, (organizationView) -> assertEquals("New VLINGO", organizationView.name()));
   }
 
   @Test

--- a/src/test/java/io/vlingo/xoom/schemata/infra/persistence/OrganizationsProjectionTest.java
+++ b/src/test/java/io/vlingo/xoom/schemata/infra/persistence/OrganizationsProjectionTest.java
@@ -5,7 +5,6 @@ import io.vlingo.xoom.schemata.model.Id.OrganizationId;
 import io.vlingo.xoom.schemata.model.Organization;
 import io.vlingo.xoom.schemata.model.OrganizationEntity;
 import io.vlingo.xoom.schemata.model.OrganizationState;
-import io.vlingo.xoom.schemata.query.view.OrganizationView;
 import io.vlingo.xoom.schemata.query.view.OrganizationsView;
 import org.junit.Test;
 
@@ -30,7 +29,7 @@ public class OrganizationsProjectionTest extends ProjectionTest {
 
   @Test
   public void itUpdatesOrganizationNameAndDescriptionOnOrganizationRedefinedEvent() {
-    final Completes<OrganizationState> organizationState = onceProjected(OrganizationView.class, () -> givenAnyOrganization()
+    final Completes<OrganizationState> organizationState = onceProjected(OrganizationsView.class, () -> givenAnyOrganization()
             .andThenTo(state -> organization(state.organizationId).redefineWith("New VLINGO", "New organization description")));
     final Completes<OrganizationsView> view = organizationState.andThenTo(state -> organizationsView());
     final Completes<OrganizationId> id = organizationState.andThen(state -> state.organizationId);
@@ -45,7 +44,7 @@ public class OrganizationsProjectionTest extends ProjectionTest {
 
   @Test
   public void itUpdatesOrganizationNameOnOrganizationRenamedEvent() {
-    final Completes<OrganizationState> organizationState = onceProjected(OrganizationView.class, () -> givenAnyOrganization()
+    final Completes<OrganizationState> organizationState = onceProjected(OrganizationsView.class, () -> givenAnyOrganization()
             .andThenTo(state -> organization(state.organizationId).renameTo("New VLINGO")));
     final Completes<OrganizationsView> view = organizationState.andThenTo(state -> organizationsView());
     final Completes<OrganizationId> id = organizationState.andThen(state -> state.organizationId);

--- a/src/test/java/io/vlingo/xoom/schemata/infra/persistence/OrganizationsProjectionTest.java
+++ b/src/test/java/io/vlingo/xoom/schemata/infra/persistence/OrganizationsProjectionTest.java
@@ -1,0 +1,67 @@
+package io.vlingo.xoom.schemata.infra.persistence;
+
+import io.vlingo.xoom.common.Completes;
+import io.vlingo.xoom.schemata.model.Id.OrganizationId;
+import io.vlingo.xoom.schemata.model.Organization;
+import io.vlingo.xoom.schemata.model.OrganizationEntity;
+import io.vlingo.xoom.schemata.model.OrganizationState;
+import io.vlingo.xoom.schemata.query.view.OrganizationView;
+import io.vlingo.xoom.schemata.query.view.OrganizationsView;
+import org.junit.Test;
+
+import static io.vlingo.xoom.schemata.test.Assertions.assertCompletes;
+import static io.vlingo.xoom.schemata.test.Assertions.assertOnNotNull;
+import static org.junit.Assert.assertEquals;
+
+public class OrganizationsProjectionTest extends ProjectionTest {
+  @Test
+  public void itCreatesOrganizationsViewOnOrganizationDefinedEvent() {
+    final Completes<OrganizationState> organizationState = givenAnyOrganization();
+    final Completes<OrganizationsView> view = organizationState.andThenTo(state -> organizationsView());
+    final Completes<OrganizationId> id = organizationState.andThen(state -> state.organizationId);
+
+    assertCompletes(view, id, (organizationsView, organizationId) ->
+            assertOnNotNull(organizationsView.get(organizationId.value), (item) -> {
+              assertEquals(Fixtures.OrgName, item.name);
+              assertEquals(Fixtures.OrgDescription, item.description);
+            })
+    );
+  }
+
+  @Test
+  public void itUpdatesOrganizationNameAndDescriptionOnOrganizationRedefinedEvent() {
+    final Completes<OrganizationState> organizationState = onceProjected(OrganizationView.class, () -> givenAnyOrganization()
+            .andThenTo(state -> organization(state.organizationId).redefineWith("New VLINGO", "New organization description")));
+    final Completes<OrganizationsView> view = organizationState.andThenTo(state -> organizationsView());
+    final Completes<OrganizationId> id = organizationState.andThen(state -> state.organizationId);
+
+    assertCompletes(view, id, (organizationsView, organizationId) ->
+            assertOnNotNull(organizationsView.get(organizationId.value), (item) -> {
+              assertEquals("New VLINGO", item.name);
+              assertEquals("New organization description", item.description);
+            })
+    );
+  }
+
+  @Test
+  public void itUpdatesOrganizationNameOnOrganizationRenamedEvent() {
+    final Completes<OrganizationState> organizationState = onceProjected(OrganizationView.class, () -> givenAnyOrganization()
+            .andThenTo(state -> organization(state.organizationId).renameTo("New VLINGO")));
+    final Completes<OrganizationsView> view = organizationState.andThenTo(state -> organizationsView());
+    final Completes<OrganizationId> id = organizationState.andThen(state -> state.organizationId);
+
+    assertCompletes(view, id, (organizationsView, organizationId) ->
+            assertOnNotNull(organizationsView.get(organizationId.value), (item) ->
+                    assertEquals("New VLINGO", item.name)
+            )
+    );
+  }
+
+  public Completes<OrganizationsView> organizationsView() {
+    return StorageProvider.instance().organizationQueries.organizations();
+  }
+
+  public Organization organization(final OrganizationId organizationId) {
+    return stage.actorFor(Organization.class, OrganizationEntity.class, organizationId);
+  }
+}

--- a/src/test/java/io/vlingo/xoom/schemata/infra/persistence/ProjectionTest.java
+++ b/src/test/java/io/vlingo/xoom/schemata/infra/persistence/ProjectionTest.java
@@ -37,14 +37,17 @@ public abstract class ProjectionTest {
   }
 
   protected Completes<SchemaVersionState> givenAnySchemaVersion(SchemaState schemaState) {
-    return onceProjected(Arrays.asList(CodeView.class, NamedSchemaView.class, SchemaVersionView.class), () -> SchemaVersion.with(
-            stage,
-            schemaState.schemaId,
-            SchemaVersionSpecification,
-            SchemaVersionDescription,
-            SchemaVersionVersion000,
-            SchemaVersionVersion100
-    ));
+    return onceProjected(
+            Arrays.asList(CodeView.class, NamedSchemaView.class, SchemaVersionView.class, SchemaVersionsView.class),
+            () -> SchemaVersion.with(
+                    stage,
+                    schemaState.schemaId,
+                    SchemaVersionSpecification,
+                    SchemaVersionDescription,
+                    SchemaVersionVersion000,
+                    SchemaVersionVersion100
+            )
+    );
   }
 
   protected Completes<SchemaState> givenAnySchema() {
@@ -55,14 +58,17 @@ public abstract class ProjectionTest {
   }
 
   protected Completes<SchemaState> givenAnySchema(ContextState context) {
-    return onceProjected(Arrays.asList(SchemaView.class, SchemasView.class, NamedSchemaView.class), () -> Schema.with(
-            stage,
-            context.contextId,
-            Fixtures.SchemaCategory,
-            Fixtures.SchemaScope,
-            Fixtures.SchemaName,
-            Fixtures.SchemaDescription
-    ));
+    return onceProjected(
+            Arrays.asList(SchemaView.class, SchemasView.class, NamedSchemaView.class, SchemaVersionsView.class),
+            () -> Schema.with(
+                    stage,
+                    context.contextId,
+                    Fixtures.SchemaCategory,
+                    Fixtures.SchemaScope,
+                    Fixtures.SchemaName,
+                    Fixtures.SchemaDescription
+            )
+    );
   }
 
   protected Completes<ContextState> givenAnyContext() {

--- a/src/test/java/io/vlingo/xoom/schemata/infra/persistence/ProjectionTest.java
+++ b/src/test/java/io/vlingo/xoom/schemata/infra/persistence/ProjectionTest.java
@@ -37,7 +37,7 @@ public abstract class ProjectionTest {
   }
 
   protected Completes<SchemaVersionState> givenAnySchemaVersion(SchemaState schemaState) {
-    return onceProjected(CodeView.class, () -> SchemaVersion.with(
+    return onceProjected(Arrays.asList(CodeView.class, NamedSchemaView.class), () -> SchemaVersion.with(
             stage,
             schemaState.schemaId,
             SchemaVersionSpecification,
@@ -55,7 +55,7 @@ public abstract class ProjectionTest {
   }
 
   protected Completes<SchemaState> givenAnySchema(ContextState context) {
-    return onceProjected(SchemaView.class, () -> Schema.with(
+    return onceProjected(Arrays.asList(SchemaView.class, NamedSchemaView.class), () -> Schema.with(
             stage,
             context.contextId,
             Fixtures.SchemaCategory,

--- a/src/test/java/io/vlingo/xoom/schemata/infra/persistence/ProjectionTest.java
+++ b/src/test/java/io/vlingo/xoom/schemata/infra/persistence/ProjectionTest.java
@@ -37,7 +37,7 @@ public abstract class ProjectionTest {
   }
 
   protected Completes<SchemaVersionState> givenAnySchemaVersion(SchemaState schemaState) {
-    return onceProjected(Arrays.asList(CodeView.class, NamedSchemaView.class), () -> SchemaVersion.with(
+    return onceProjected(Arrays.asList(CodeView.class, NamedSchemaView.class, SchemaVersionView.class), () -> SchemaVersion.with(
             stage,
             schemaState.schemaId,
             SchemaVersionSpecification,

--- a/src/test/java/io/vlingo/xoom/schemata/infra/persistence/ProjectionTest.java
+++ b/src/test/java/io/vlingo/xoom/schemata/infra/persistence/ProjectionTest.java
@@ -12,7 +12,9 @@ import io.vlingo.xoom.schemata.test.symbio.FakeStateStoreDispatcher;
 import org.junit.After;
 import org.junit.Before;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.function.Supplier;
 
 import static io.vlingo.xoom.schemata.infra.persistence.Fixtures.*;
@@ -23,6 +25,10 @@ public abstract class ProjectionTest {
 
   protected <R> R onceProjected(Class<?> projectionType, Supplier<R> supplier) {
     return stateStoreDispatcher.onceProjected(projectionType, supplier);
+  }
+
+  protected <R> R onceProjected(List<Class<?>> projectionTypes, Supplier<R> supplier) {
+    return stateStoreDispatcher.onceProjected(projectionTypes, supplier);
   }
 
   protected Completes<SchemaVersionState> givenAnySchemaVersion() {
@@ -65,7 +71,7 @@ public abstract class ProjectionTest {
   }
 
   protected Completes<ContextState> givenAnyContext(UnitState unit) {
-    return onceProjected(ContextView.class, () -> Context.with(
+    return onceProjected(Arrays.asList(ContextView.class, ContextsView.class), () -> Context.with(
             stage,
             unit.unitId,
             Fixtures.ContextNamespace,
@@ -79,7 +85,7 @@ public abstract class ProjectionTest {
   }
 
   protected Completes<UnitState> givenAnyUnit(OrganizationState organization) {
-    return onceProjected(UnitView.class, () -> Unit.with(
+    return onceProjected(Arrays.asList(UnitView.class, ContextsView.class), () -> Unit.with(
             stage,
             organization.organizationId,
             Fixtures.UnitName,

--- a/src/test/java/io/vlingo/xoom/schemata/infra/persistence/ProjectionTest.java
+++ b/src/test/java/io/vlingo/xoom/schemata/infra/persistence/ProjectionTest.java
@@ -55,7 +55,7 @@ public abstract class ProjectionTest {
   }
 
   protected Completes<SchemaState> givenAnySchema(ContextState context) {
-    return onceProjected(Arrays.asList(SchemaView.class, NamedSchemaView.class), () -> Schema.with(
+    return onceProjected(Arrays.asList(SchemaView.class, SchemasView.class, NamedSchemaView.class), () -> Schema.with(
             stage,
             context.contextId,
             Fixtures.SchemaCategory,
@@ -71,7 +71,7 @@ public abstract class ProjectionTest {
   }
 
   protected Completes<ContextState> givenAnyContext(UnitState unit) {
-    return onceProjected(Arrays.asList(ContextView.class, ContextsView.class), () -> Context.with(
+    return onceProjected(Arrays.asList(ContextView.class, ContextsView.class, SchemasView.class), () -> Context.with(
             stage,
             unit.unitId,
             Fixtures.ContextNamespace,

--- a/src/test/java/io/vlingo/xoom/schemata/infra/persistence/ProjectionTest.java
+++ b/src/test/java/io/vlingo/xoom/schemata/infra/persistence/ProjectionTest.java
@@ -91,7 +91,7 @@ public abstract class ProjectionTest {
   }
 
   protected Completes<UnitState> givenAnyUnit(OrganizationState organization) {
-    return onceProjected(Arrays.asList(UnitView.class, ContextsView.class), () -> Unit.with(
+    return onceProjected(Arrays.asList(UnitView.class, UnitsView.class, ContextsView.class), () -> Unit.with(
             stage,
             organization.organizationId,
             Fixtures.UnitName,
@@ -100,11 +100,10 @@ public abstract class ProjectionTest {
   }
 
   protected Completes<OrganizationState> givenAnyOrganization() {
-    return onceProjected(Arrays.asList(OrganizationView.class, OrganizationsView.class), () -> Organization.with(
-            stage,
-            OrgName,
-            OrgDescription
-    ));
+    return onceProjected(
+            Arrays.asList(OrganizationView.class, OrganizationsView.class, UnitsView.class),
+            () -> Organization.with(stage, OrgName, OrgDescription)
+    );
   }
 
   @Before

--- a/src/test/java/io/vlingo/xoom/schemata/infra/persistence/ProjectionTest.java
+++ b/src/test/java/io/vlingo/xoom/schemata/infra/persistence/ProjectionTest.java
@@ -59,6 +59,11 @@ public abstract class ProjectionTest {
     ));
   }
 
+  protected Completes<ContextState> givenAnyContext() {
+    return givenAnyUnit()
+            .andThenTo(this::givenAnyContext);
+  }
+
   protected Completes<ContextState> givenAnyContext(UnitState unit) {
     return onceProjected(ContextView.class, () -> Context.with(
             stage,
@@ -66,6 +71,11 @@ public abstract class ProjectionTest {
             Fixtures.ContextNamespace,
             Fixtures.ContextDescription
     ));
+  }
+
+  protected Completes<UnitState> givenAnyUnit() {
+    return givenAnyOrganization()
+            .andThenTo(this::givenAnyUnit);
   }
 
   protected Completes<UnitState> givenAnyUnit(OrganizationState organization) {

--- a/src/test/java/io/vlingo/xoom/schemata/infra/persistence/ProjectionTest.java
+++ b/src/test/java/io/vlingo/xoom/schemata/infra/persistence/ProjectionTest.java
@@ -94,7 +94,11 @@ public abstract class ProjectionTest {
   }
 
   protected Completes<OrganizationState> givenAnyOrganization() {
-    return onceProjected(OrganizationView.class, () -> Organization.with(stage, OrgName, OrgDescription));
+    return onceProjected(Arrays.asList(OrganizationView.class, OrganizationsView.class), () -> Organization.with(
+            stage,
+            OrgName,
+            OrgDescription
+    ));
   }
 
   @Before

--- a/src/test/java/io/vlingo/xoom/schemata/infra/persistence/ProjectionTest.java
+++ b/src/test/java/io/vlingo/xoom/schemata/infra/persistence/ProjectionTest.java
@@ -1,0 +1,100 @@
+package io.vlingo.xoom.schemata.infra.persistence;
+
+import io.vlingo.xoom.actors.Configuration;
+import io.vlingo.xoom.cluster.ClusterProperties;
+import io.vlingo.xoom.common.Completes;
+import io.vlingo.xoom.lattice.grid.Grid;
+import io.vlingo.xoom.schemata.Schemata;
+import io.vlingo.xoom.schemata.SchemataConfig;
+import io.vlingo.xoom.schemata.model.*;
+import io.vlingo.xoom.schemata.query.view.*;
+import io.vlingo.xoom.schemata.test.symbio.FakeStateStoreDispatcher;
+import org.junit.After;
+import org.junit.Before;
+
+import java.util.Collections;
+import java.util.function.Supplier;
+
+import static io.vlingo.xoom.schemata.infra.persistence.Fixtures.*;
+
+public abstract class ProjectionTest {
+  protected Grid stage;
+  private FakeStateStoreDispatcher stateStoreDispatcher;
+
+  protected <R> R onceProjected(Class<?> projectionType, Supplier<R> supplier) {
+    return stateStoreDispatcher.onceProjected(projectionType, supplier);
+  }
+
+  protected Completes<SchemaVersionState> givenAnySchemaVersion() {
+    return givenAnySchema()
+            .andThenTo(this::givenAnySchemaVersion);
+  }
+
+  protected Completes<SchemaVersionState> givenAnySchemaVersion(SchemaState schemaState) {
+    return onceProjected(CodeView.class, () -> SchemaVersion.with(
+            stage,
+            schemaState.schemaId,
+            SchemaVersionSpecification,
+            SchemaVersionDescription,
+            SchemaVersionVersion000,
+            SchemaVersionVersion100
+    ));
+  }
+
+  protected Completes<SchemaState> givenAnySchema() {
+    return givenAnyOrganization()
+            .andThenTo(this::givenAnyUnit)
+            .andThenTo(this::givenAnyContext)
+            .andThenTo(this::givenAnySchema);
+  }
+
+  protected Completes<SchemaState> givenAnySchema(ContextState context) {
+    return onceProjected(SchemaView.class, () -> Schema.with(
+            stage,
+            context.contextId,
+            Fixtures.SchemaCategory,
+            Fixtures.SchemaScope,
+            Fixtures.SchemaName,
+            Fixtures.SchemaDescription
+    ));
+  }
+
+  protected Completes<ContextState> givenAnyContext(UnitState unit) {
+    return onceProjected(ContextView.class, () -> Context.with(
+            stage,
+            unit.unitId,
+            Fixtures.ContextNamespace,
+            Fixtures.ContextDescription
+    ));
+  }
+
+  protected Completes<UnitState> givenAnyUnit(OrganizationState organization) {
+    return onceProjected(UnitView.class, () -> Unit.with(
+            stage,
+            organization.organizationId,
+            Fixtures.UnitName,
+            Fixtures.UnitDescription
+    ));
+  }
+
+  protected Completes<OrganizationState> givenAnyOrganization() {
+    return onceProjected(OrganizationView.class, () -> Organization.with(stage, OrgName, OrgDescription));
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    stage = Grid.start("test-projection", Configuration.define(), ClusterProperties.oneNode(), Schemata.NodeName);
+    stateStoreDispatcher = new FakeStateStoreDispatcher(stage.world().defaultLogger());
+
+    final SchemataConfig config = SchemataConfig.forRuntime(SchemataConfig.RUNTIME_TYPE_DEV);
+    final StateStoreProvider stateStoreProvider = StateStoreProvider.using(stage.world(), config, Collections.singletonList(stateStoreDispatcher));
+    final ProjectionDispatcherProvider projectionDispatcherProvider = ProjectionDispatcherProvider.using(stage, stateStoreProvider.stateStore);
+
+    StorageProvider.newInstance(stage.world(), stateStoreProvider.stateStore, projectionDispatcherProvider.storeDispatcher, config);
+  }
+
+  @After
+  public void tearDown() {
+    stage.world().terminate();
+  }
+}

--- a/src/test/java/io/vlingo/xoom/schemata/infra/persistence/ProjectionTest.java
+++ b/src/test/java/io/vlingo/xoom/schemata/infra/persistence/ProjectionTest.java
@@ -1,10 +1,11 @@
 package io.vlingo.xoom.schemata.infra.persistence;
 
 import io.vlingo.xoom.actors.Configuration;
-import io.vlingo.xoom.cluster.ClusterProperties;
+import io.vlingo.xoom.actors.Stage;
+import io.vlingo.xoom.actors.UUIDAddressFactory;
+import io.vlingo.xoom.actors.World;
 import io.vlingo.xoom.common.Completes;
-import io.vlingo.xoom.lattice.grid.Grid;
-import io.vlingo.xoom.schemata.Schemata;
+import io.vlingo.xoom.common.identity.IdentityGeneratorType;
 import io.vlingo.xoom.schemata.SchemataConfig;
 import io.vlingo.xoom.schemata.model.*;
 import io.vlingo.xoom.schemata.query.view.*;
@@ -20,7 +21,8 @@ import java.util.function.Supplier;
 import static io.vlingo.xoom.schemata.infra.persistence.Fixtures.*;
 
 public abstract class ProjectionTest {
-  protected Grid stage;
+  protected Stage stage;
+  protected World world;
   private FakeStateStoreDispatcher stateStoreDispatcher;
 
   protected <R> R onceProjected(Class<?> projectionType, Supplier<R> supplier) {
@@ -108,7 +110,8 @@ public abstract class ProjectionTest {
 
   @Before
   public void setUp() throws Exception {
-    stage = Grid.start("test-projection", Configuration.define(), ClusterProperties.oneNode(), Schemata.NodeName);
+    world = World.start("test-projection", Configuration.define().with(new UUIDAddressFactory(IdentityGeneratorType.RANDOM)));
+    stage = world.stage();
     stateStoreDispatcher = new FakeStateStoreDispatcher(stage.world().defaultLogger());
 
     final SchemataConfig config = SchemataConfig.forRuntime(SchemataConfig.RUNTIME_TYPE_DEV);
@@ -120,6 +123,6 @@ public abstract class ProjectionTest {
 
   @After
   public void tearDown() {
-    stage.world().terminate();
+    world.terminate();
   }
 }

--- a/src/test/java/io/vlingo/xoom/schemata/infra/persistence/SchemaProjectionTest.java
+++ b/src/test/java/io/vlingo/xoom/schemata/infra/persistence/SchemaProjectionTest.java
@@ -1,0 +1,99 @@
+package io.vlingo.xoom.schemata.infra.persistence;
+
+import io.vlingo.xoom.common.Completes;
+import io.vlingo.xoom.schemata.model.*;
+import io.vlingo.xoom.schemata.model.Id.SchemaId;
+import io.vlingo.xoom.schemata.query.view.SchemaView;
+import org.junit.Test;
+
+import static io.vlingo.xoom.schemata.test.Assertions.assertCompletes;
+import static org.junit.Assert.assertEquals;
+
+public class SchemaProjectionTest extends ProjectionTest {
+
+  @Test
+  public void itCreatesSchemaViewOnSchemaDefinedEvent() {
+    final Completes<SchemaState> schemaState = givenAnySchema();
+    final Completes<SchemaView> view = schemaState.andThenTo(state -> schemaView(state.schemaId));
+
+    assertCompletes(view, (schemaView) -> {
+      assertEquals(Fixtures.SchemaCategory, schemaView.category());
+      assertEquals(Fixtures.SchemaName, schemaView.name());
+      assertEquals(Fixtures.SchemaDescription, schemaView.description());
+      assertEquals(Fixtures.SchemaScope, schemaView.scope());
+    });
+  }
+
+  @Test
+  public void itUpdatesTheSchemaViewOnSchemaCategorisedEvent() {
+    final Completes<SchemaState> schemaState = onceProjected(SchemaView.class, () ->
+            givenAnySchema().andThenTo(state -> schema(state.schemaId).categorizeAs(Category.Command))
+    );
+    final Completes<SchemaView> view = schemaState.andThenTo(state -> schemaView(state.schemaId));
+
+    assertCompletes(view, (schemaView) -> assertEquals(Category.Command, schemaView.category()));
+  }
+
+  @Test
+  public void itUpdatesTheSchemaViewOnSchemaScopedEvent() {
+    final Completes<SchemaState> schemaState = onceProjected(SchemaView.class, () ->
+            givenAnySchema().andThenTo(state -> schema(state.schemaId).scopeAs(Scope.Private))
+    );
+    final Completes<SchemaView> view = schemaState.andThenTo(state -> schemaView(state.schemaId));
+
+    assertCompletes(view, (schemaView) -> assertEquals(Scope.Private, schemaView.scope()));
+  }
+
+  @Test
+  public void itUpdatesTheSchemaViewOnSchemaRenamedEvent() {
+    final Completes<SchemaState> schemaState = onceProjected(SchemaView.class, () ->
+            givenAnySchema().andThenTo(state -> schema(state.schemaId).renameTo("New schema"))
+    );
+    final Completes<SchemaView> view = schemaState.andThenTo(state -> schemaView(state.schemaId));
+
+    assertCompletes(view, (schemaView) -> assertEquals("New schema", schemaView.name()));
+  }
+
+  @Test
+  public void itUpdatesTheSchemaViewOnSchemaDescribedEvent() {
+    final Completes<SchemaState> schemaState = onceProjected(SchemaView.class, () ->
+            givenAnySchema().andThenTo(state -> schema(state.schemaId).describeAs("New description"))
+    );
+    final Completes<SchemaView> view = schemaState.andThenTo(state -> schemaView(state.schemaId));
+
+    assertCompletes(view, (schemaView) -> assertEquals("New description", schemaView.description()));
+  }
+
+  @Test
+  public void itUpdatesTheSchemaViewOnSchemaRedefinedEvent() {
+    final Completes<SchemaState> schemaState = onceProjected(SchemaView.class, () ->
+            givenAnySchema().andThenTo(state -> schema(state.schemaId).redefineWith(
+                    Category.Command,
+                    Scope.Private,
+                    "New name",
+                    "New description"
+            ))
+    );
+    final Completes<SchemaView> view = schemaState.andThenTo(state -> schemaView(state.schemaId));
+
+    assertCompletes(view, (schemaView) -> {
+      assertEquals(Category.Command, schemaView.category());
+      assertEquals(Scope.Private, schemaView.scope());
+      assertEquals("New name", schemaView.name());
+      assertEquals("New description", schemaView.description());
+    });
+  }
+
+  public Completes<SchemaView> schemaView(final SchemaId schemaId) {
+    return StorageProvider.instance().schemaQueries.schema(
+            schemaId.organizationId().value,
+            schemaId.unitId().value,
+            schemaId.contextId.value,
+            schemaId.value
+    );
+  }
+
+  public Schema schema(final SchemaId schemaId) {
+    return stage.actorFor(Schema.class, SchemaEntity.class, schemaId);
+  }
+}

--- a/src/test/java/io/vlingo/xoom/schemata/infra/persistence/SchemaVersionProjectionTest.java
+++ b/src/test/java/io/vlingo/xoom/schemata/infra/persistence/SchemaVersionProjectionTest.java
@@ -1,0 +1,96 @@
+package io.vlingo.xoom.schemata.infra.persistence;
+
+import io.vlingo.xoom.common.Completes;
+import io.vlingo.xoom.schemata.model.Id.SchemaVersionId;
+import io.vlingo.xoom.schemata.model.SchemaVersion;
+import io.vlingo.xoom.schemata.model.SchemaVersion.Specification;
+import io.vlingo.xoom.schemata.model.SchemaVersionEntity;
+import io.vlingo.xoom.schemata.model.SchemaVersionState;
+import io.vlingo.xoom.schemata.query.view.SchemaVersionView;
+import org.junit.Test;
+
+import static io.vlingo.xoom.schemata.test.Assertions.assertCompletes;
+import static org.junit.Assert.assertEquals;
+
+public class SchemaVersionProjectionTest extends ProjectionTest {
+
+  @Test
+  public void itCreatesSchemaVersionViewOnSchemaVersionDefinedEvent() {
+    final Completes<SchemaVersionView> schemaVersionView = givenAnySchemaVersion()
+            .andThenTo(state -> schemaVersionView(state.schemaVersionId));
+
+    assertCompletes(schemaVersionView, (view) -> {
+      assertEquals(Fixtures.SchemaVersionDescription, view.description());
+      assertEquals(Fixtures.SchemaVersionSpecification.value, view.specification());
+      assertEquals(Fixtures.SchemaVersionVersion000.value, view.previousVersion());
+      assertEquals(Fixtures.SchemaVersionVersion100.value, view.currentVersion());
+      assertEquals(SchemaVersion.Status.Draft.value, view.status());
+    });
+  }
+
+  @Test
+  public void itUpdatesSchemaVersionViewOnSchemaVersionDescribedEvent() {
+    final Completes<SchemaVersionState> schemaVersionState = onceProjected(SchemaVersionView.class, () -> givenAnySchemaVersion()
+            .andThenTo(state -> schemaVersion(state.schemaVersionId).describeAs("New description")));
+    final Completes<SchemaVersionView> schemaVersionView = schemaVersionState
+            .andThenTo(state -> schemaVersionView(state.schemaVersionId));
+
+    assertCompletes(schemaVersionView, (view) -> assertEquals("New description", view.description()));
+  }
+
+  @Test
+  public void itUpdatesSchemaVersionOnSchemaVersionSpecifiedEvent() {
+    final String newSpecification = "event SchemaDefined { type eventType }";
+    final Completes<SchemaVersionState> schemaVersionState = onceProjected(SchemaVersionView.class, () -> givenAnySchemaVersion()
+            .andThenTo(state -> schemaVersion(state.schemaVersionId).specifyWith(Specification.of(newSpecification))));
+    final Completes<SchemaVersionView> schemaVersionView = schemaVersionState
+            .andThenTo(state -> schemaVersionView(state.schemaVersionId));
+
+    assertCompletes(schemaVersionView, (view) -> assertEquals(newSpecification, view.specification()));
+  }
+
+  @Test
+  public void itUpdatesSchemaVersionOnSchemaVersionPublishedEvent() {
+    final Completes<SchemaVersionState> schemaVersionState = onceProjected(SchemaVersionView.class, () -> givenAnySchemaVersion()
+            .andThenTo(state -> schemaVersion(state.schemaVersionId).publish()));
+    final Completes<SchemaVersionView> schemaVersionView = schemaVersionState
+            .andThenTo(state -> schemaVersionView(state.schemaVersionId));
+
+    assertCompletes(schemaVersionView, (view) -> assertEquals(SchemaVersion.Status.Published.value, view.status()));
+  }
+
+  @Test
+  public void itUpdatesSchemaVersionOnSchemaVersionDeprecatedEvent() {
+    final Completes<SchemaVersionState> schemaVersionState = givenAnySchemaVersion();
+    onceProjected(SchemaVersionView.class, () -> schemaVersionState.andThenTo(state -> schemaVersion(state.schemaVersionId).publish()));
+    onceProjected(SchemaVersionView.class, () -> schemaVersionState.andThenTo(state -> schemaVersion(state.schemaVersionId).deprecate()));
+    final Completes<SchemaVersionView> schemaVersionView = schemaVersionState.andThenTo(state -> schemaVersionView(state.schemaVersionId));
+
+    assertCompletes(schemaVersionView, (view) -> assertEquals(SchemaVersion.Status.Deprecated.value, view.status()));
+  }
+
+  @Test
+  public void itUpdatesSchemaVersionOnSchemaVersionRemovedEvent() {
+    final Completes<SchemaVersionState> schemaVersionState = givenAnySchemaVersion();
+    onceProjected(SchemaVersionView.class, () -> schemaVersionState.andThenTo(state -> schemaVersion(state.schemaVersionId).publish()));
+    onceProjected(SchemaVersionView.class, () -> schemaVersionState.andThenTo(state -> schemaVersion(state.schemaVersionId).deprecate()));
+    onceProjected(SchemaVersionView.class, () -> schemaVersionState.andThenTo(state -> schemaVersion(state.schemaVersionId).remove()));
+    final Completes<SchemaVersionView> schemaVersionView = schemaVersionState.andThenTo(state -> schemaVersionView(state.schemaVersionId));
+
+    assertCompletes(schemaVersionView, (view) -> assertEquals(SchemaVersion.Status.Removed.value, view.status()));
+  }
+
+  private Completes<SchemaVersionView> schemaVersionView(final SchemaVersionId schemaVersionId) {
+    return StorageProvider.instance().schemaVersionQueries.schemaVersion(
+            schemaVersionId.organizationId().value,
+            schemaVersionId.unitId().value,
+            schemaVersionId.contextId().value,
+            schemaVersionId.schemaId.value,
+            schemaVersionId.value
+    );
+  }
+
+  private SchemaVersion schemaVersion(final SchemaVersionId schemaVersionId) {
+    return stage.actorFor(SchemaVersion.class, SchemaVersionEntity.class, schemaVersionId);
+  }
+}

--- a/src/test/java/io/vlingo/xoom/schemata/infra/persistence/SchemaVersionsProjectionTest.java
+++ b/src/test/java/io/vlingo/xoom/schemata/infra/persistence/SchemaVersionsProjectionTest.java
@@ -1,0 +1,140 @@
+package io.vlingo.xoom.schemata.infra.persistence;
+
+import io.vlingo.xoom.common.Completes;
+import io.vlingo.xoom.schemata.model.Id.SchemaId;
+import io.vlingo.xoom.schemata.model.Id.SchemaVersionId;
+import io.vlingo.xoom.schemata.model.SchemaVersion;
+import io.vlingo.xoom.schemata.model.SchemaVersion.Specification;
+import io.vlingo.xoom.schemata.model.SchemaVersionEntity;
+import io.vlingo.xoom.schemata.model.SchemaVersionState;
+import io.vlingo.xoom.schemata.query.view.SchemaVersionsView;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static io.vlingo.xoom.schemata.test.Assertions.assertCompletes;
+import static io.vlingo.xoom.schemata.test.Assertions.assertOnNotNull;
+import static org.junit.Assert.assertEquals;
+
+public class SchemaVersionsProjectionTest extends ProjectionTest {
+
+  @Test
+  public void itCreatesSchemaVersionsViewOnSchemaDefinedEvent() {
+    final Completes<SchemaVersionsView> schemaVersionsView = givenAnySchema().andThenTo(state -> schemaVersionsView(state.schemaId));
+
+    assertCompletes(schemaVersionsView, (view) -> assertEquals(Collections.emptyList(), view.all()));
+  }
+
+  @Test
+  public void itUpdatesSchemaVersionsViewOnSchemaVersionDefinedEvent() {
+    final Completes<SchemaVersionState> schemaVersionState = givenAnySchemaVersion();
+    final Completes<SchemaVersionsView> schemaVersionsView = schemaVersionState.andThenTo(state -> schemaVersionsView(state.schemaVersionId));
+    final Completes<SchemaVersionId> schemaVersionId = schemaVersionState.andThen(state -> state.schemaVersionId);
+
+    assertCompletes(schemaVersionsView, schemaVersionId, (view, id) ->
+            assertOnNotNull(view.get(id.value), (schemaVersionView) -> {
+              assertEquals(Fixtures.SchemaVersionDescription, schemaVersionView.description());
+              assertEquals(Fixtures.SchemaVersionSpecification.value, schemaVersionView.specification());
+              assertEquals(Fixtures.SchemaVersionVersion000.value, schemaVersionView.previousVersion());
+              assertEquals(Fixtures.SchemaVersionVersion100.value, schemaVersionView.currentVersion());
+              assertEquals(SchemaVersion.Status.Draft.value, schemaVersionView.status());
+            })
+    );
+  }
+
+  @Test
+  public void itUpdatesSchemaVersionsViewOnSchemaVersionDescribedEvent() {
+    final Completes<SchemaVersionState> schemaVersionState = onceProjected(SchemaVersionsView.class, () -> givenAnySchemaVersion()
+            .andThenTo(state -> schemaVersion(state.schemaVersionId).describeAs("New description")));
+    final Completes<SchemaVersionsView> schemaVersionsView = schemaVersionState
+            .andThenTo(state -> schemaVersionsView(state.schemaVersionId));
+    final Completes<SchemaVersionId> schemaVersionId = schemaVersionState.andThen(state -> state.schemaVersionId);
+
+    assertCompletes(schemaVersionsView, schemaVersionId, (view, id) ->
+            assertOnNotNull(view.get(id.value), (schemaVersionView) ->
+                    assertEquals("New description", schemaVersionView.description())
+            )
+    );
+  }
+
+  @Test
+  public void itUpdatesSchemaVersionsViewOnSchemaVersionSpecifiedEvent() {
+    final String newSpecification = "event SchemaDefined { type eventType }";
+    final Completes<SchemaVersionState> schemaVersionState = onceProjected(SchemaVersionsView.class, () -> givenAnySchemaVersion()
+            .andThenTo(state -> schemaVersion(state.schemaVersionId).specifyWith(Specification.of(newSpecification))));
+    final Completes<SchemaVersionsView> schemaVersionsView = schemaVersionState
+            .andThenTo(state -> schemaVersionsView(state.schemaVersionId));
+    final Completes<SchemaVersionId> schemaVersionId = schemaVersionState.andThen(state -> state.schemaVersionId);
+
+    assertCompletes(schemaVersionsView, schemaVersionId, (view, id) ->
+            assertOnNotNull(view.get(id.value), (schemaVersionView) ->
+                    assertEquals(newSpecification, schemaVersionView.specification())
+            )
+    );
+  }
+
+  @Test
+  public void itUpdatesSchemaVersionsViewOnSchemaVersionPublishedEvent() {
+    final Completes<SchemaVersionState> schemaVersionState = onceProjected(SchemaVersionsView.class, () -> givenAnySchemaVersion()
+            .andThenTo(state -> schemaVersion(state.schemaVersionId).publish()));
+    final Completes<SchemaVersionsView> schemaVersionsView = schemaVersionState
+            .andThenTo(state -> schemaVersionsView(state.schemaVersionId));
+    final Completes<SchemaVersionId> schemaVersionId = schemaVersionState.andThen(state -> state.schemaVersionId);
+
+    assertCompletes(schemaVersionsView, schemaVersionId, (view, id) ->
+            assertOnNotNull(view.get(id.value), (schemaVersionView) ->
+                    assertEquals(SchemaVersion.Status.Published.value, schemaVersionView.status())
+            )
+    );
+  }
+
+  @Test
+  public void itUpdatesSchemaVersionsViewOnSchemaVersionDeprecatedEvent() {
+    final Completes<SchemaVersionState> schemaVersionState = givenAnySchemaVersion();
+    onceProjected(SchemaVersionsView.class, () -> schemaVersionState.andThenTo(state -> schemaVersion(state.schemaVersionId).publish()));
+    onceProjected(SchemaVersionsView.class, () -> schemaVersionState.andThenTo(state -> schemaVersion(state.schemaVersionId).deprecate()));
+    final Completes<SchemaVersionsView> schemaVersionsView = schemaVersionState
+            .andThenTo(state -> schemaVersionsView(state.schemaVersionId));
+    final Completes<SchemaVersionId> schemaVersionId = schemaVersionState.andThen(state -> state.schemaVersionId);
+
+    assertCompletes(schemaVersionsView, schemaVersionId, (view, id) ->
+            assertOnNotNull(view.get(id.value), (schemaVersionView) ->
+                    assertEquals(SchemaVersion.Status.Deprecated.value, schemaVersionView.status())
+            )
+    );
+  }
+
+  @Test
+  public void itUpdatesSchemaVersionsViewOnSchemaVersionRemovedEvent() {
+    final Completes<SchemaVersionState> schemaVersionState = givenAnySchemaVersion();
+    onceProjected(SchemaVersionsView.class, () -> schemaVersionState.andThenTo(state -> schemaVersion(state.schemaVersionId).publish()));
+    onceProjected(SchemaVersionsView.class, () -> schemaVersionState.andThenTo(state -> schemaVersion(state.schemaVersionId).deprecate()));
+    onceProjected(SchemaVersionsView.class, () -> schemaVersionState.andThenTo(state -> schemaVersion(state.schemaVersionId).remove()));
+    final Completes<SchemaVersionsView> schemaVersionsView = schemaVersionState
+            .andThenTo(state -> schemaVersionsView(state.schemaVersionId));
+    final Completes<SchemaVersionId> schemaVersionId = schemaVersionState.andThen(state -> state.schemaVersionId);
+
+    assertCompletes(schemaVersionsView, schemaVersionId, (view, id) ->
+            assertOnNotNull(view.get(id.value), (schemaVersionView) ->
+                    assertEquals(SchemaVersion.Status.Removed.value, schemaVersionView.status())
+            )
+    );
+  }
+
+  private Completes<SchemaVersionsView> schemaVersionsView(final SchemaId schemaId) {
+    return StorageProvider.instance().schemaVersionQueries.schemaVersionsByIds(
+            schemaId.organizationId().value,
+            schemaId.unitId().value,
+            schemaId.contextId.value,
+            schemaId.value
+    );
+  }
+
+  private Completes<SchemaVersionsView> schemaVersionsView(final SchemaVersionId schemaVersionId) {
+    return schemaVersionsView(schemaVersionId.schemaId);
+  }
+
+  private SchemaVersion schemaVersion(final SchemaVersionId schemaVersionId) {
+    return stage.actorFor(SchemaVersion.class, SchemaVersionEntity.class, schemaVersionId);
+  }
+}

--- a/src/test/java/io/vlingo/xoom/schemata/infra/persistence/SchemasProjectionTest.java
+++ b/src/test/java/io/vlingo/xoom/schemata/infra/persistence/SchemasProjectionTest.java
@@ -1,0 +1,93 @@
+package io.vlingo.xoom.schemata.infra.persistence;
+
+import io.vlingo.xoom.common.Completes;
+import io.vlingo.xoom.schemata.model.*;
+import io.vlingo.xoom.schemata.model.Id.ContextId;
+import io.vlingo.xoom.schemata.model.Id.SchemaId;
+import io.vlingo.xoom.schemata.query.view.SchemasView;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static io.vlingo.xoom.schemata.test.Assertions.assertCompletes;
+import static io.vlingo.xoom.schemata.test.Assertions.assertOnNotNull;
+import static org.junit.Assert.assertEquals;
+
+public class SchemasProjectionTest extends ProjectionTest {
+
+  @Test
+  public void itCreatesSchemaViewOnContextDefinedEvent() {
+    Completes<ContextState> contextState = givenAnyContext();
+    Completes<SchemasView> view = contextState.andThenTo(state -> schemasView(state.contextId));
+    assertCompletes(view, (schemasView) -> assertEquals(Collections.emptyList(), schemasView.all()));
+  }
+
+  @Test
+  public void itAddsSchemaToSchemasViewOnSchemaDefinedEvent() {
+    final Completes<SchemaState> schemaState = givenAnySchema();
+    final Completes<SchemasView> view = schemaState.andThenTo(state -> schemasView(state.schemaId));
+    final Completes<SchemaId> id = schemaState.andThen(state -> state.schemaId);
+
+    assertCompletes(view, id, (schemasView, schemaId) ->
+            assertOnNotNull(schemasView.get(schemaId.value), (schemaItem) -> {
+              assertEquals(Fixtures.SchemaCategory.name(), schemaItem.category);
+              assertEquals(Fixtures.SchemaScope.name(), schemaItem.scope);
+              assertEquals(Fixtures.SchemaName, schemaItem.name);
+              assertEquals(Fixtures.SchemaDescription, schemaItem.description);
+            })
+    );
+  }
+
+  @Test
+  public void itUpdatesSchemasViewOnSchemaRedefinedEvent() {
+    final Completes<SchemaState> schemaState = onceProjected(SchemasView.class, () ->
+            givenAnySchema().andThenTo(state -> schema(state.schemaId)
+                    .redefineWith(Category.Command, Scope.Private, "New name", "New description")
+            )
+    );
+    final Completes<SchemasView> view = schemaState.andThenTo(state -> schemasView(state.schemaId));
+    final Completes<SchemaId> id = schemaState.andThen(state -> state.schemaId);
+
+    assertCompletes(view, id, (schemasView, schemaId) ->
+            assertOnNotNull(schemasView.get(schemaId.value), (schemaItem) -> {
+              assertEquals(Category.Command.name(), schemaItem.category);
+              assertEquals(Scope.Private.name(), schemaItem.scope);
+              assertEquals("New name", schemaItem.name);
+              assertEquals("New description", schemaItem.description);
+            })
+    );
+  }
+
+  @Test
+  public void itUpdatesSchemasViewOnSchemaRenamedEvent() {
+    final Completes<SchemaState> schemaState = onceProjected(SchemasView.class, () ->
+            givenAnySchema().andThenTo(state -> schema(state.schemaId)
+                    .renameTo("New XOOM Schema")
+            )
+    );
+    final Completes<SchemasView> view = schemaState.andThenTo(state -> schemasView(state.schemaId));
+    final Completes<SchemaId> id = schemaState.andThen(state -> state.schemaId);
+
+    assertCompletes(view, id, (schemasView, schemaId) ->
+            assertOnNotNull(schemasView.get(schemaId.value), (schemaItem) ->
+                    assertEquals("New XOOM Schema", schemaItem.name)
+            )
+    );
+  }
+
+  public Completes<SchemasView> schemasView(final SchemaId schemaId) {
+    return schemasView(schemaId.contextId);
+  }
+
+  private Completes<SchemasView> schemasView(final ContextId contextId) {
+    return StorageProvider.instance().schemaQueries.schemas(
+            contextId.organizationId().value,
+            contextId.unitId.value,
+            contextId.value
+    );
+  }
+
+  public Schema schema(final SchemaId schemaId) {
+    return stage.actorFor(Schema.class, SchemaEntity.class, schemaId);
+  }
+}

--- a/src/test/java/io/vlingo/xoom/schemata/infra/persistence/UnitProjectionTest.java
+++ b/src/test/java/io/vlingo/xoom/schemata/infra/persistence/UnitProjectionTest.java
@@ -1,0 +1,63 @@
+package io.vlingo.xoom.schemata.infra.persistence;
+
+import io.vlingo.xoom.common.Completes;
+import io.vlingo.xoom.schemata.model.Id.UnitId;
+import io.vlingo.xoom.schemata.model.Unit;
+import io.vlingo.xoom.schemata.model.UnitEntity;
+import io.vlingo.xoom.schemata.model.UnitState;
+import io.vlingo.xoom.schemata.query.view.UnitView;
+import org.junit.Test;
+
+import static io.vlingo.xoom.schemata.test.Assertions.assertCompletes;
+import static org.junit.Assert.assertEquals;
+
+public class UnitProjectionTest extends ProjectionTest {
+
+  @Test
+  public void itCreatesUnitViewOnUnitDefinedEvent() {
+    final Completes<UnitView> unitView = givenAnyUnit().andThenTo(state -> unitView(state.unitId));
+
+    assertCompletes(unitView, (view) -> {
+      assertEquals(Fixtures.UnitName, view.name());
+      assertEquals(Fixtures.UnitDescription, view.description());
+    });
+  }
+
+  @Test
+  public void itUpdatesUnitViewOnUnitDescribedEvent() {
+    final Completes<UnitState> unitState = onceProjected(UnitView.class, () -> givenAnyUnit()
+            .andThenTo(state -> unit(state.unitId).describeAs("New UNIT")));
+    final Completes<UnitView> unitView = unitState.andThenTo(state -> unitView(state.unitId));
+
+    assertCompletes(unitView, (view) -> assertEquals("New UNIT", view.description()));
+  }
+
+  @Test
+  public void itUpdatesUnitViewOnUnitRedefinedEvent() {
+    final Completes<UnitState> unitState = onceProjected(UnitView.class, () -> givenAnyUnit()
+            .andThenTo(state -> unit(state.unitId).redefineWith("New Name", "New UNIT")));
+    final Completes<UnitView> unitView = unitState.andThenTo(state -> unitView(state.unitId));
+
+    assertCompletes(unitView, (view) -> {
+      assertEquals("New Name", view.name());
+      assertEquals("New UNIT", view.description());
+    });
+  }
+
+  @Test
+  public void itUpdatesUnitViewOnUnitRenamedEvent() {
+    final Completes<UnitState> unitState = onceProjected(UnitView.class, () -> givenAnyUnit()
+            .andThenTo(state -> unit(state.unitId).renameTo("New Name")));
+    final Completes<UnitView> unitView = unitState.andThenTo(state -> unitView(state.unitId));
+
+    assertCompletes(unitView, (view) -> assertEquals("New Name", view.name()));
+  }
+
+  private Completes<UnitView> unitView(UnitId unitId) {
+    return StorageProvider.instance().unitQueries.unit(unitId.organizationId.value, unitId.value);
+  }
+
+  private Unit unit(UnitId unitId) {
+    return stage.actorFor(Unit.class, UnitEntity.class, unitId);
+  }
+}

--- a/src/test/java/io/vlingo/xoom/schemata/infra/persistence/UnitsProjectionTest.java
+++ b/src/test/java/io/vlingo/xoom/schemata/infra/persistence/UnitsProjectionTest.java
@@ -1,0 +1,81 @@
+package io.vlingo.xoom.schemata.infra.persistence;
+
+import io.vlingo.xoom.common.Completes;
+import io.vlingo.xoom.schemata.model.Id.OrganizationId;
+import io.vlingo.xoom.schemata.model.Id.UnitId;
+import io.vlingo.xoom.schemata.model.Unit;
+import io.vlingo.xoom.schemata.model.UnitEntity;
+import io.vlingo.xoom.schemata.model.UnitState;
+import io.vlingo.xoom.schemata.query.view.UnitsView;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static io.vlingo.xoom.schemata.test.Assertions.assertCompletes;
+import static io.vlingo.xoom.schemata.test.Assertions.assertOnNotNull;
+import static org.junit.Assert.assertEquals;
+
+public class UnitsProjectionTest extends ProjectionTest {
+
+  @Test
+  public void itCreatesUnitsViewOnOrganizationDefinedEvent() {
+    final Completes<UnitsView> unitsView = givenAnyOrganization().andThenTo(state -> unitsView(state.organizationId));
+
+    assertCompletes(unitsView, (view) -> assertEquals(Collections.emptyList(), view.all()));
+  }
+
+  @Test
+  public void itUpdatesUnitsViewOnUnitDefinedEvent() {
+    final Completes<UnitState> unitState = givenAnyUnit();
+    final Completes<UnitsView> unitsView = unitState.andThenTo(state -> unitsView(state.unitId));
+    final Completes<UnitId> unitId = unitState.andThen(state -> state.unitId);
+
+    assertCompletes(unitsView, unitId, (view, id) ->
+            assertOnNotNull(view.get(id.value), (unitItem) -> {
+              assertEquals(Fixtures.UnitName, unitItem.name);
+              assertEquals(Fixtures.UnitDescription, unitItem.description);
+            })
+    );
+  }
+
+  @Test
+  public void itUpdatesUnitsViewOnUnitRedefinedEvent() {
+    final Completes<UnitState> unitState = onceProjected(UnitsView.class, () -> givenAnyUnit()
+            .andThenTo(state -> unit(state.unitId).redefineWith("New name", "New description")));
+    final Completes<UnitsView> unitsView = unitState.andThenTo(state -> unitsView(state.unitId));
+    final Completes<UnitId> unitId = unitState.andThen(state -> state.unitId);
+
+    assertCompletes(unitsView, unitId, (view, id) ->
+            assertOnNotNull(view.get(id.value), (unitItem) -> {
+              assertEquals("New name", unitItem.name);
+              assertEquals("New description", unitItem.description);
+            })
+    );
+  }
+
+  @Test
+  public void itUpdatesUnitsViewOnUnitRenamedEvent() {
+    final Completes<UnitState> unitState = onceProjected(UnitsView.class, () -> givenAnyUnit()
+            .andThenTo(state -> unit(state.unitId).renameTo("New name")));
+    final Completes<UnitsView> unitsView = unitState.andThenTo(state -> unitsView(state.unitId));
+    final Completes<UnitId> unitId = unitState.andThen(state -> state.unitId);
+
+    assertCompletes(unitsView, unitId, (view, id) ->
+            assertOnNotNull(view.get(id.value), (unitItem) ->
+                    assertEquals("New name", unitItem.name)
+            )
+    );
+  }
+
+  private Completes<UnitsView> unitsView(UnitId unitId) {
+    return unitsView(unitId.organizationId);
+  }
+
+  private Completes<UnitsView> unitsView(OrganizationId organizationId) {
+    return StorageProvider.instance().unitQueries.units(organizationId.value);
+  }
+
+  private Unit unit(UnitId unitId) {
+    return stage.actorFor(Unit.class, UnitEntity.class, unitId);
+  }
+}

--- a/src/test/java/io/vlingo/xoom/schemata/test/Assertions.java
+++ b/src/test/java/io/vlingo/xoom/schemata/test/Assertions.java
@@ -2,6 +2,7 @@ package io.vlingo.xoom.schemata.test;
 
 import io.vlingo.xoom.common.Completes;
 
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 import static org.junit.Assert.assertNotEquals;
@@ -18,6 +19,33 @@ public class Assertions {
     final T outcome = completes.await(2000);
     assertNotEquals(null, outcome);
     assertions.accept(outcome);
+  }
+
+  /**
+   * Makes assertions on outcomes of two asynchronous operations.
+   * @param completes1 the eventual completion of the first asynchronous operation
+   * @param completes2 the eventual completion of the second asynchronous operation
+   * @param assertions the consumer of completed operations that will be called to make assertions
+   * @param <T> the type of the first outcome
+   * @param <R> the type of the second outcome
+   */
+  public static <T, R> void assertCompletes(Completes<T> completes1, Completes<R> completes2, BiConsumer<T, R> assertions) {
+    final T outcome1 = completes1.await(2000);
+    final R outcome2 = completes2.await(2000);
+    assertNotEquals(null, outcome1);
+    assertNotEquals(null, outcome2);
+    assertions.accept(outcome1, outcome2);
+  }
+
+  /**
+   * Makes sure the value isn't null before passing it to the assertions callback.
+   * @param value the value to be used with assertions
+   * @param assertions the consumer of a non-null value that will be called to make assertions
+   * @param <T> the type of the value
+   */
+  public static <T> void assertOnNotNull(T value, Consumer<T> assertions) {
+    assertNotEquals(null, value);
+    assertions.accept(value);
   }
 
 }

--- a/src/test/java/io/vlingo/xoom/schemata/test/Assertions.java
+++ b/src/test/java/io/vlingo/xoom/schemata/test/Assertions.java
@@ -1,0 +1,23 @@
+package io.vlingo.xoom.schemata.test;
+
+import io.vlingo.xoom.common.Completes;
+
+import java.util.function.Consumer;
+
+import static org.junit.Assert.assertNotEquals;
+
+public class Assertions {
+
+  /**
+   * Makes assertions on an outcome of an asynchronous operation.
+   * @param completes the eventual completion of an asynchronous operation
+   * @param assertions the consumer of the completed operation that will be called to make assertions
+   * @param <T> the type of the outcome
+   */
+  public static <T> void assertCompletes(Completes<T> completes, Consumer<T> assertions) {
+    final T outcome = completes.await(2000);
+    assertNotEquals(null, outcome);
+    assertions.accept(outcome);
+  }
+
+}

--- a/src/test/java/io/vlingo/xoom/schemata/test/symbio/FakeStateStoreDispatcher.java
+++ b/src/test/java/io/vlingo/xoom/schemata/test/symbio/FakeStateStoreDispatcher.java
@@ -1,0 +1,88 @@
+package io.vlingo.xoom.schemata.test.symbio;
+
+import io.vlingo.xoom.actors.Logger;
+import io.vlingo.xoom.actors.testkit.AccessSafely;
+import io.vlingo.xoom.actors.testkit.TestUntil;
+import io.vlingo.xoom.symbio.Entry;
+import io.vlingo.xoom.symbio.State;
+import io.vlingo.xoom.symbio.store.Result;
+import io.vlingo.xoom.symbio.store.dispatch.Dispatchable;
+import io.vlingo.xoom.symbio.store.dispatch.Dispatcher;
+import io.vlingo.xoom.symbio.store.dispatch.DispatcherControl;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+/**
+ * StateStore Dispatcher implementation that allows to synchronize based on expected dispatchable types.
+ *
+ * <code>
+ *   FakeStateStoreDispatcher dispatcher = new FakeStateStoreDispatcher(logger);
+ *   MyEntity entity = dispatcher.onceProjected(MyView.class, () -> {
+ *     // some code that's expected to trigger a projection to MyView
+ *     return MyEntity.empty();
+ *   });
+ * </code>
+ */
+public class FakeStateStoreDispatcher implements Dispatcher<Dispatchable<? extends Entry<?>, ? extends State<?>>> {
+  private final Logger logger;
+  private DispatcherControl control = null;
+  final private Map<String, List<TestUntil>> expectations = new HashMap<>();
+  final private AccessSafely access = AccessSafely.immediately()
+          .writingWith("registerExpectation", (String type, TestUntil expectation) -> expectations.compute(type, (key, oldExpectationStack) -> {
+            List<TestUntil> expectationStack = oldExpectationStack == null ? new ArrayList<>() : oldExpectationStack;
+            expectationStack.add(expectation);
+            return expectationStack;
+          }))
+          .writingWith("matchExpectation", (String type) -> expectations.forEach((expectedType, expectationStack) -> {
+            if (expectedType.equals(type)) {
+              final TestUntil expectation = expectationStack.get(expectationStack.size() - 1);
+              expectation.happened();
+              if (expectation.remaining() == 0) {
+                expectationStack.remove(expectation);
+              }
+            }
+          }));
+
+  public FakeStateStoreDispatcher(Logger logger) {
+    this.logger = logger;
+  }
+
+  @Override
+  public void controlWith(DispatcherControl dispatcherControl) {
+    control = dispatcherControl;
+  }
+
+  @Override
+  public void dispatch(Dispatchable<? extends Entry<?>, ? extends State<?>> dispatchable) {
+    dispatchable.state().ifPresent(state -> logger.info(String.format("DISPATCHED %s", state.id)));
+    if (control != null) {
+      control.confirmDispatched(dispatchable.id(), (Result result, String dispatchId) -> {
+        logger.info(String.format("DISPATCH %s for %s", result, dispatchId));
+        dispatchable.state().ifPresent(state -> access.writeUsing("matchExpectation", state.type));
+      });
+    }
+  }
+
+  /**
+   * Calls the supplier and returns the result as soon as given type is projected.
+   */
+  public <R> R onceProjected(Class<?> type, Supplier<R> supplier) {
+    return onceProjected(type, 1, supplier);
+  }
+
+  /**
+   * Calls the supplier and returns the result as soon as given type is projected a given number of times.
+   */
+  public <R> R onceProjected(Class<?> type, int times, Supplier<R> supplier) {
+    final TestUntil expectation = TestUntil.happenings(times);
+    access.writeUsing("registerExpectation", type.getCanonicalName(), expectation);
+    R result = supplier.get();
+    // Do not wait indefinitely, but long enough for most delays
+    expectation.completesWithin(30000);
+    return result;
+  }
+}


### PR DESCRIPTION
When trying to add a new projection I noticed projections are mostly tested in resource tests. Scope of such tests is quite wide.

I also noticed that when many entities are projected in a single test, projections tend to be created "out of order". This sometimes leads to failing tests. For example, CodeView cannot be created before SchemaView is persisted first. This wouldn't normally happen in an application serving real clients, but can easily happen in tests as they operate on multiple entities almost simultaniously.

Having dedicated projection tests would make the scope of resource tests smaller and let us write more focused tests.

Below's an example of a projection test. The test will wait for a projection to create the view before proceeding to querying it:

https://github.com/vlingo/xoom-schemata/blob/08e4f4735eea6dedfeef1b6541d6a4ca413d116f/src/test/java/io/vlingo/xoom/schemata/infra/persistence/CodeProjectionTest.java#L18-L37

Actually, all the methods that create fixtures will wait for appropriate view:

https://github.com/vlingo/xoom-schemata/blob/08e4f4735eea6dedfeef1b6541d6a4ca413d116f/src/test/java/io/vlingo/xoom/schemata/infra/persistence/ProjectionTest.java#L80-L82
