### PR TITLE
Prevent hanging of requests for schema dependencies

### DIFF
--- a/src/main/java/io/vlingo/xoom/schemata/codegen/TypeDependenciesRetrieverActor.java
+++ b/src/main/java/io/vlingo/xoom/schemata/codegen/TypeDependenciesRetrieverActor.java
@@ -15,6 +15,7 @@ import io.vlingo.xoom.schemata.query.CodeQueries;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -35,8 +36,10 @@ public class TypeDependenciesRetrieverActor extends Actor implements TypeDepende
               final InputStream spec = new ByteArrayInputStream(codeView.specification().getBytes());
               return middleware.compileToAST(spec, rootReference);
             }).andThen(outcome -> {
-              final TypeDefinition type = (TypeDefinition) outcome.resolve(ex -> ex, node -> node);
-              final Set<String> schemaNames = resolveComplexTypedSchemaNames(type);
+              final Set<String> schemaNames = outcome.resolve(
+                      ex -> Collections.emptySet(),
+                      node -> resolveComplexTypedSchemaNames((TypeDefinition) node)
+              );
               final TypeDependencies typeDependencies = TypeDependencies.with(rootReference);
               typeDependencies.add(schemaNames);
               return typeDependencies;

--- a/src/main/java/io/vlingo/xoom/schemata/infra/persistence/SchemaVersionLookUpActor.java
+++ b/src/main/java/io/vlingo/xoom/schemata/infra/persistence/SchemaVersionLookUpActor.java
@@ -22,7 +22,7 @@ import io.vlingo.xoom.schemata.query.view.SchemaView;
 import io.vlingo.xoom.schemata.query.view.UnitView;
 import io.vlingo.xoom.schemata.query.view.View;
 
-class SchemaVersionLookUpActor extends Actor implements SchemaVersionLookUp {
+public class SchemaVersionLookUpActor extends Actor implements SchemaVersionLookUp {
   private final SchemaVersionLookUp lookUp;
   private final String nextVersion;
   private final Projectable projectable;

--- a/src/main/java/io/vlingo/xoom/schemata/infra/persistence/SchemaVersionQueryExecutor.java
+++ b/src/main/java/io/vlingo/xoom/schemata/infra/persistence/SchemaVersionQueryExecutor.java
@@ -11,7 +11,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
-class SchemaVersionQueryExecutor {
+public class SchemaVersionQueryExecutor {
   private final AtomicBoolean busy;
   private final Consumer<SchemaVersionQueryExecutor> queryRunner;
   private final AtomicReference<String> value;

--- a/src/main/java/io/vlingo/xoom/schemata/resource/SchemaResource.java
+++ b/src/main/java/io/vlingo/xoom/schemata/resource/SchemaResource.java
@@ -136,7 +136,8 @@ public class SchemaResource extends DynamicResourceHandler {
   public Completes<Response> querySchemaDependencies(final String reference) {
     return TypeDependenciesRetriever.with(stage(), codeQueries).dependenciesOf(reference)
             .andThen(typeDependencies -> typeDependencies.dependencyReferences)
-            .andThenTo(dependencyReferences -> Completes.withSuccess(Response.of(Ok, serialized(dependencyReferences))));
+            .andThenTo(dependencyReferences -> Completes.withSuccess(Response.of(Ok, serialized(dependencyReferences))))
+            .otherwise(e -> Response.of(NotFound));
   }
 
   @Override

--- a/src/test/java/io/vlingo/xoom/schemata/resource/AbstractRestTest.java
+++ b/src/test/java/io/vlingo/xoom/schemata/resource/AbstractRestTest.java
@@ -36,6 +36,7 @@ public abstract class AbstractRestTest {
     @After
     public void cleanUp() throws InterruptedException {
         System.out.println("==== Test Server shutting down ");
+        StorageProvider.clear();
         xoom.terminateWorld();
         waitServerClose();
     }

--- a/src/test/java/io/vlingo/xoom/schemata/resource/SchemaDependenciesResourceTest.java
+++ b/src/test/java/io/vlingo/xoom/schemata/resource/SchemaDependenciesResourceTest.java
@@ -45,6 +45,17 @@ public class SchemaDependenciesResourceTest extends AbstractRestTest {
     assertTrue(dependencies.contains("Vlingo:store:io.vlingo.store.logistics:Price:1.0.0"));
   }
 
+  @Test
+  public void testThatItReturns404IfSchemaIsNotFound() {
+    loadSchemas();
+
+    final String reference =
+            Path.with(OrgName, UnitName, Context, "ProductDelivered", "2.0.0").toReference();
+
+    given().when().get(String.format("/api/schemas/%s/dependencies", reference))
+            .then().statusCode(404);
+  }
+
   private void loadSchemas() {
     final String organizationId =
             given().when().body(OrganizationData.just(OrgName, OrgName))


### PR DESCRIPTION
I think this has proved we should discourage (or make it impossible) for end users to use `completesEventually()` with `completes()` directly:

```java
CompletesEventually completes = completesEventually();
eventualOutcome.andFinallyConsume((R value) -> completes.with(value));
return completes();
````

and suggest using `answerFrom()` instead:

```java
return answerFrom(eventualOutcome);
```

Related PRs:

* https://github.com/vlingo/xoom-common/pull/44
* https://github.com/vlingo/xoom-actors/pull/91